### PR TITLE
[Feat] #3 내 식물 목록 (홈 화면)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig {
         httpSecurity
                 .csrf().disable()
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/signup", "/auth/login", "/auth/validate").permitAll()
+                        .requestMatchers("/auth/signup", "/auth/login", "/auth/validate", "/user-plants").permitAll()
                         .anyRequest().authenticated());
         return httpSecurity.build();
     }

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -17,7 +17,18 @@ public class SecurityConfig {
         httpSecurity
                 .csrf().disable()
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/signup", "/auth/login", "/auth/validate", "/user-plants").permitAll()
+                        .requestMatchers(
+                                "/auth/signup",
+                                "/auth/login",
+                                "/auth/validate",
+                                "/user-plants",
+
+                                // Swagger 경로들
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
                         .anyRequest().authenticated());
         return httpSecurity.build();
     }

--- a/src/main/java/com/BioTy/Planty/config/SwaggerConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.BioTy.Planty.config;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class SwaggerConfig {
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI(){
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(SECURITY_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                )
+                .info(new Info().title("Planty API").version("v1"));
+    }
+}

--- a/src/main/java/com/BioTy/Planty/controller/AuthController.java
+++ b/src/main/java/com/BioTy/Planty/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.BioTy.Planty.dto.user.LoginResponseDto;
 import com.BioTy.Planty.dto.user.SignupRequestDto;
 import com.BioTy.Planty.security.JwtUtil;
 import com.BioTy.Planty.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
@@ -12,6 +14,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auth", description = "회원가입, 로그인, 토큰 검증 API")
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -20,6 +23,7 @@ public class AuthController {
     private final JwtUtil jwtUtil;
 
     // 1. 회원가입
+    @Operation(summary = "회원가입", description = "이메일과 비밀번호로 회원가입합니다.")
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody SignupRequestDto signupRequestDto){
         authService.signup(signupRequestDto);
@@ -27,6 +31,7 @@ public class AuthController {
     }
 
     // 2. 로그인
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequestDto){
         LoginResponseDto loginResponseDto = authService.login(loginRequestDto);
@@ -34,6 +39,7 @@ public class AuthController {
     }
 
     // 3. 토큰 유효성 검사
+    @Operation(summary = "토큰 유효성 검사", description = "JWT 토큰이 유효한지 검사합니다.")
     @GetMapping("/validate")
     public ResponseEntity<Void> validateToken(@RequestHeader("Authorization") String authHeader){
         if(authHeader == null || !authHeader.startsWith("Bearer ")){

--- a/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
+++ b/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
@@ -1,0 +1,33 @@
+package com.BioTy.Planty.controller;
+
+import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
+import com.BioTy.Planty.service.AuthService;
+import com.BioTy.Planty.service.UserPlantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/user-plants")
+@RequiredArgsConstructor
+public class UserPlantController {
+    private final UserPlantService userPlantService;
+    private final AuthService authService;
+
+    // 로그인한 사용자의 반려 식물 조회 (홈)
+    @GetMapping
+    public ResponseEntity<List<UserPlantSummaryResponseDto>> getUserPlants(
+            @RequestHeader("Authorization") String token
+    ){
+        token = token.replace("Bearer ", "");
+        Long userId = authService.getUserIdFromToken(token);
+
+        List<UserPlantSummaryResponseDto> response = userPlantService.getUserPlants(userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
+++ b/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
@@ -3,6 +3,10 @@ package com.BioTy.Planty.controller;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 import com.BioTy.Planty.service.AuthService;
 import com.BioTy.Planty.service.UserPlantService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "UserPlant", description = "사용자의 반려식물 관련 API")
 @RestController
 @RequestMapping("/user-plants")
 @RequiredArgsConstructor
@@ -20,8 +25,12 @@ public class UserPlantController {
     private final AuthService authService;
 
     // 로그인한 사용자의 반려 식물 조회 (홈)
+    @Operation(summary = "사용자의 반려식물 목록 조회",
+            description = "JWT 토큰을 통해 사용자의 식물 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
     @GetMapping
     public ResponseEntity<List<UserPlantSummaryResponseDto>> getUserPlants(
+            @Parameter(hidden = true)
             @RequestHeader("Authorization") String token
     ){
         token = token.replace("Bearer ", "");

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantSummaryResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantSummaryResponseDto.java
@@ -1,0 +1,36 @@
+package com.BioTy.Planty.dto.userPlant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UserPlantSummaryResponseDto {
+    private Long userPlantId;
+    private String nickname;
+    private String imageUrl;
+    private LocalDate adoptedAt;
+
+    private Status status;
+    private Personality personality;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Status{
+        private Integer temperatureScore;
+        private Integer lightScore;
+        private Integer humidityScore;
+        private String message;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Personality{
+        private String label;
+        private String emoji;
+        private String color;
+    }
+
+}

--- a/src/main/java/com/BioTy/Planty/entity/Personality.java
+++ b/src/main/java/com/BioTy/Planty/entity/Personality.java
@@ -1,0 +1,29 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Personality {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String label;
+    private String emoji;
+    private String color;
+
+    public Personality(String label, String emoji, String color){
+        this.label = label;
+        this.emoji = emoji;
+        this.color = color;
+    }
+
+}

--- a/src/main/java/com/BioTy/Planty/entity/PlantStatus.java
+++ b/src/main/java/com/BioTy/Planty/entity/PlantStatus.java
@@ -1,0 +1,38 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlantStatus {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_plant_id", nullable = false)
+    private UserPlant userPlant;
+
+    private Integer temperatureScore;
+    private Integer lightScore;
+    private Integer humidityScore;
+
+    private String statusMessage;
+    private LocalDateTime checkedAt;
+
+    public PlantStatus(UserPlant userPlant, Integer temperatureScore, Integer humidityScore,
+                       Integer lightScore, Integer waterScore, String statusMessage, LocalDateTime checkedAt) {
+        this.userPlant = userPlant;
+        this.temperatureScore = temperatureScore;
+        this.lightScore = lightScore;
+        this.humidityScore = humidityScore;
+        this.statusMessage = statusMessage;
+        this.checkedAt = checkedAt;
+    }
+}

--- a/src/main/java/com/BioTy/Planty/entity/UserPlant.java
+++ b/src/main/java/com/BioTy/Planty/entity/UserPlant.java
@@ -1,0 +1,49 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPlant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private String nickname;
+    private String imageUrl;
+    private LocalDate adoptedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personality_id", nullable = false)
+    private Personality personality;
+
+    @OneToMany(mappedBy = "userPlant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PlantStatus> statuses = new ArrayList<>();
+
+    public PlantStatus getLatestStatus(){
+        return statuses.stream()
+                .max(Comparator.comparing(PlantStatus::getCheckedAt))
+                .orElse(null);
+    }
+
+    public UserPlant(User user, String nickname, String imageUrl, LocalDate adoptedAt, Personality personality){
+        this.user = user;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+        this.adoptedAt = adoptedAt;
+        this.personality = personality;
+    }
+}

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepository.java
@@ -1,0 +1,12 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.UserPlant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserPlantRepository extends JpaRepository<UserPlant, Long>, UserPlantRepositoryCustom{
+
+}

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryCustom.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.UserPlant;
+
+import java.util.List;
+
+public interface UserPlantRepositoryCustom {
+    List<UserPlant> findAllWithLatestStatusAndPersonalityByUserId(Long userId);
+}

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryCustom.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryCustom.java
@@ -1,9 +1,9 @@
 package com.BioTy.Planty.repository;
 
-import com.BioTy.Planty.entity.UserPlant;
+import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 
 import java.util.List;
 
 public interface UserPlantRepositoryCustom {
-    List<UserPlant> findAllWithLatestStatusAndPersonalityByUserId(Long userId);
+    List<UserPlantSummaryResponseDto> findSummaryDtoByUserId(Long userId);
 }

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
@@ -1,8 +1,7 @@
 package com.BioTy.Planty.repository;
 
-import com.BioTy.Planty.entity.UserPlant;
+import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.Id;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -12,29 +11,55 @@ import java.util.List;
 @Repository
 @RequiredArgsConstructor
 public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
-
     @PersistenceContext
     private EntityManager em;
 
     @Override
-    public List<UserPlant> findAllWithLatestStatusAndPersonalityByUserId(Long userId) {
+    public List<UserPlantSummaryResponseDto> findSummaryDtoByUserId(Long userId) {
         String sql = """
-                SELECT up.*
-                FROM user_plant up
-                LEFT JOIN personality p ON up.personality_id = p.id
-                LEFT JOIN plant_status ps ON ps.user_plant_id = up.id
-                WHERE up.user_id = ?1
-                    AND ps.checked_at = (
-                        SELECT MAX(inner_ps.checked_at)
-                        FROM plant_status inner_ps
-                        WHERE inner_ps.user_plant_id = up.id
-                    )
-                """;
+            SELECT 
+              up.id AS userPlantId,
+              up.nickname,
+              up.image_url AS imageUrl,
+              up.adopted_at AS adoptedAt,
+              ps.temperature_score,
+              ps.light_score,
+              ps.humidity_score,
+              ps.status_message,
+              p.label AS personality_label,
+              p.emoji AS personality_emoji,
+              p.color AS personality_color
+            FROM user_plant up
+            LEFT JOIN personality p ON up.personality_id = p.id
+            LEFT JOIN plant_status ps ON ps.user_plant_id = up.id
+            WHERE up.user_id = ?1
+              AND ps.checked_at = (
+                  SELECT MAX(inner_ps.checked_at)
+                  FROM plant_status inner_ps
+                  WHERE inner_ps.user_plant_id = up.id
+              )
+        """;
 
-        List<UserPlant> result = em.createNativeQuery(sql, UserPlant.class)
+        List<Object[]> rows = em.createNativeQuery(sql)
                 .setParameter(1, userId)
                 .getResultList();
 
-        return result;
+        return rows.stream().map(row -> new UserPlantSummaryResponseDto(
+                ((Number) row[0]).longValue(),         // userPlantId
+                (String) row[1],                       // nickname
+                (String) row[2],                       // imageUrl
+                ((java.sql.Date) row[3]).toLocalDate(),// adoptedAt
+                new UserPlantSummaryResponseDto.Status(
+                        (Integer) row[4],
+                        (Integer) row[5],
+                        (Integer) row[6],
+                        (String) row[7]
+                ),
+                new UserPlantSummaryResponseDto.Personality(
+                        (String) row[8],
+                        (String) row[9],
+                        (String) row[10]
+                )
+        )).toList();
     }
 }

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.UserPlant;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public List<UserPlant> findAllWithLatestStatusAndPersonalityByUserId(Long userId) {
+        String sql = """
+                SELECT up.*
+                FROM user_plant up
+                LEFT JOIN personality p ON up.personality_id = p.id
+                LEFT JOIN plant_status ps ON ps.user_plant_id = up.id
+                WHERE up.user_id = ?1
+                    AND ps.checked_at = (
+                        SELECT MAX(inner_ps.checked_at)
+                        FROM plant_status inner_ps
+                        WHERE inner_ps.user_plant_id = up.id
+                    )
+                """;
+
+        List<UserPlant> result = em.createNativeQuery(sql, UserPlant.class)
+                .setParameter(1, userId)
+                .getResultList();
+
+        return result;
+    }
+}

--- a/src/main/java/com/BioTy/Planty/service/AuthService.java
+++ b/src/main/java/com/BioTy/Planty/service/AuthService.java
@@ -41,4 +41,12 @@ public class AuthService {
         return new LoginResponseDto(token);
     }
 
+    // 3. 토큰 → userId 추출
+    public Long getUserIdFromToken(String token) {
+        String email = jwtUtil.getEmailFromToken(token);
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."))
+                .getId();
+    }
+
 }

--- a/src/main/java/com/BioTy/Planty/service/UserPlantService.java
+++ b/src/main/java/com/BioTy/Planty/service/UserPlantService.java
@@ -1,0 +1,18 @@
+package com.BioTy.Planty.service;
+
+import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
+import com.BioTy.Planty.repository.UserPlantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserPlantService {
+    private final UserPlantRepository userPlantRepository;
+
+    public List<UserPlantSummaryResponseDto> getUserPlants(Long userId){
+        return userPlantRepository.findSummaryDtoByUserId(userId);
+    }
+}


### PR DESCRIPTION
### Pull Request
사용자의 반려식물 목록 조회 API 구현

**🪾작업한 브랜치**
- feat/# 3-home

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-BE/issues/3
- https://github.com/Team-BIoTy/Planty-FE/issues/2

**🔥 작업 내용**
- 사용자 반려식물 목록 조회 API 구현 (GET /user-plants)
- Native Query 기반 `UserPlantRepository` 구현
- `UserPlantController`에서 토큰 기반 사용자 식물 목록 응답
- Swagger 문서화, 테스트 및 Flutter 연동 완료

**🚀 추후 고려사항 (성능 개선 & 확장성)**
1. 서비스 메서드별 실행 시간 로깅
→ 느린 구간 파악을 위한 로그 추가 (System.currentTimeMillis() 또는 AOP)

2. DB 인덱스 확인 및 추가
→ user_id, checked_at 등 자주 조회되는 컬럼에 인덱스 적용

3. 쿼리 방식 개선 (Projection 사용)
→ NativeQuery 대신 JPA Projection 방식 적용으로 가독성과 유지보수 향상

4. 식물 목록 페이징 처리 도입
→ 데이터 양 증가에 대비한 Pageable 도입으로 네트워크/성능 최적화

5. Redis 캐싱 도입
→ 자주 조회되는 홈화면 데이터 캐싱하여 응답 속도 개선 및 DB 부하 분산

