### PR TITLE
[Feat] #4 식물 등록

### DIFF
--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
                                 "/auth/login",
                                 "/auth/validate",
                                 "/user-plants",
+                                "/plants",
 
                                 // Swagger 경로들
                                 "/swagger-ui/**",

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
                                 "/auth/login",
                                 "/auth/validate",
                                 "/user-plants",
+                                "/personalities",
                                 "/plants",
                                 "/plants/{plnatId}",
 

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
                                 "/auth/validate",
                                 "/user-plants",
                                 "/plants",
+                                "/plants/{plnatId}",
 
                                 // Swagger 경로들
                                 "/swagger-ui/**",

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
                                 "/auth/login",
                                 "/auth/validate",
                                 "/user-plants",
+                                "/user-plants/{userPlantId}/device",
                                 "/personalities",
                                 "/plants",
                                 "/plants/{plnatId}",

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
                                 "/personalities",
                                 "/plants",
                                 "/plants/{plnatId}",
+                                "/iot-devices",
 
                                 // Swagger 경로들
                                 "/swagger-ui/**",

--- a/src/main/java/com/BioTy/Planty/controller/IotDeviceController.java
+++ b/src/main/java/com/BioTy/Planty/controller/IotDeviceController.java
@@ -1,0 +1,49 @@
+package com.BioTy.Planty.controller;
+
+import com.BioTy.Planty.dto.iot.IotDeviceResponseDto;
+import com.BioTy.Planty.entity.IotDevice;
+import com.BioTy.Planty.service.AuthService;
+import com.BioTy.Planty.service.IotDeviceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Tag(name = "IotDevice", description = "사용자의 IoT 기기 API")
+@RestController
+@RequestMapping("/iot-devices")
+@RequiredArgsConstructor
+public class IotDeviceController {
+    private final IotDeviceService iotDeviceService;
+    private final AuthService authService;
+
+    @Operation(
+            summary = "사용자의 IoT 기기 목록 조회",
+            description = "JWT 토큰을 통해 현재 사용자의 IoT 기기 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping
+    public ResponseEntity<List<IotDeviceResponseDto>> getMyDevices(
+            @Parameter(hidden = true)
+            @RequestHeader("Authorization") String token
+    ) {
+        token = token.replace("Bearer ", "");
+        Long userId = authService.getUserIdFromToken(token);
+        List<IotDevice> devices = iotDeviceService.getDevicesByUserId(userId);
+
+        List<IotDeviceResponseDto> response = devices.stream()
+                .map(IotDeviceResponseDto::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/BioTy/Planty/controller/PersonalityController.java
+++ b/src/main/java/com/BioTy/Planty/controller/PersonalityController.java
@@ -1,0 +1,30 @@
+package com.BioTy.Planty.controller;
+
+import com.BioTy.Planty.dto.userPlant.PersonalityResponseDto;
+import com.BioTy.Planty.service.UserPlantService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Personality", description = "식물 성격 관련 API")
+@RestController
+@RequestMapping("/personalities")
+@RequiredArgsConstructor
+public class PersonalityController {
+    private final UserPlantService userPlantService;
+
+    // 성격 조회
+    @GetMapping
+    @Operation(
+            summary = "식물 성격 목록 조회",
+            description = "반려식물 등록 시 선택할 수 있는 성격 목록을 반환합니다."
+    )
+    public List<PersonalityResponseDto> getAllPersonalities(){
+        return userPlantService.getAllPersonalities();
+    }
+}

--- a/src/main/java/com/BioTy/Planty/controller/PlantInfoController.java
+++ b/src/main/java/com/BioTy/Planty/controller/PlantInfoController.java
@@ -1,5 +1,6 @@
 package com.BioTy.Planty.controller;
 
+import com.BioTy.Planty.dto.plant.PlantInfoDetailResponseDto;
 import com.BioTy.Planty.dto.plant.PlantInfoListResponseDto;
 import com.BioTy.Planty.service.PlantInfoService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,5 +27,11 @@ public class PlantInfoController {
     public ResponseEntity<List<PlantInfoListResponseDto>> getAllPlants(){
         List<PlantInfoListResponseDto> response = plantInfoService.getAllPlantInfoLists();
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "도감 식물 상세 정보 조회", description = "선택한 식물의 상세 정보를 조회합니다.")
+    @GetMapping("/{plantId}")
+    public PlantInfoDetailResponseDto getPlantDetail(@PathVariable Long plantId) {
+        return plantInfoService.getPlantInfoDetail(plantId);
     }
 }

--- a/src/main/java/com/BioTy/Planty/controller/PlantInfoController.java
+++ b/src/main/java/com/BioTy/Planty/controller/PlantInfoController.java
@@ -1,0 +1,29 @@
+package com.BioTy.Planty.controller;
+
+import com.BioTy.Planty.dto.plant.PlantInfoListResponseDto;
+import com.BioTy.Planty.service.PlantInfoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "PlantInfo", description = "식물 도감 관련 API")
+@RestController
+@RequestMapping("/plants")
+@RequiredArgsConstructor
+public class PlantInfoController {
+    private final PlantInfoService plantInfoService;
+
+    @Operation(summary = "전체 식물 도감 목록 조회", description = "모든 식물 정보를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<PlantInfoListResponseDto>> getAllPlants(){
+        List<PlantInfoListResponseDto> response = plantInfoService.getAllPlantInfoLists();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
+++ b/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
@@ -1,5 +1,6 @@
 package com.BioTy.Planty.controller;
 
+import com.BioTy.Planty.dto.iot.RegisterDeviceRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantCreateRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 import com.BioTy.Planty.service.AuthService;
@@ -39,11 +40,11 @@ public class UserPlantController {
     }
 
     // 사용자 식물 등록
-    @PostMapping
     @Operation(
             summary = "반려식물 등록",
             description = "사용자가 선택한 식물 정보(도감), 애칭, 입양일, 성격을 입력하여 반려식물을 등록합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
+    @PostMapping
     public ResponseEntity<Long> registerUserPlant(
             @Parameter(hidden = true)
             @RequestHeader("Authorization") String token,
@@ -54,5 +55,20 @@ public class UserPlantController {
 
         Long userPlantId = userPlantService.registerUserPlant(requestDto, userId);
         return ResponseEntity.ok(userPlantId);
+    }
+
+    // iot 기기 등록
+    @Operation(
+            summary = "IoT 기기 연결",
+            description = "사용자의 반려식물과 IoT 기기를 연결합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/{userPlantId}/device")
+    public ResponseEntity<Void> registerIotDevice(
+            @Parameter(description = "반려식물 ID") @PathVariable Long userPlantId,
+            @RequestBody RegisterDeviceRequestDto requestDto
+    ){
+        userPlantService.registerDevice(userPlantId, requestDto.getIotDeviceId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
+++ b/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
@@ -1,5 +1,6 @@
 package com.BioTy.Planty.controller;
 
+import com.BioTy.Planty.dto.userPlant.UserPlantCreateRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 import com.BioTy.Planty.service.AuthService;
 import com.BioTy.Planty.service.UserPlantService;
@@ -9,10 +10,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -38,5 +36,23 @@ public class UserPlantController {
 
         List<UserPlantSummaryResponseDto> response = userPlantService.getUserPlants(userId);
         return ResponseEntity.ok(response);
+    }
+
+    // 사용자 식물 등록
+    @PostMapping
+    @Operation(
+            summary = "반려식물 등록",
+            description = "사용자가 선택한 식물 정보(도감), 애칭, 입양일, 성격을 입력하여 반려식물을 등록합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    public ResponseEntity<Long> registerUserPlant(
+            @Parameter(hidden = true)
+            @RequestHeader("Authorization") String token,
+            @RequestBody UserPlantCreateRequestDto requestDto
+    ){
+        token = token.replace("Bearer ", "");
+        Long userId = authService.getUserIdFromToken(token);
+
+        Long userPlantId = userPlantService.registerUserPlant(requestDto, userId);
+        return ResponseEntity.ok(userPlantId);
     }
 }

--- a/src/main/java/com/BioTy/Planty/dto/iot/IotDeviceResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/iot/IotDeviceResponseDto.java
@@ -1,0 +1,23 @@
+package com.BioTy.Planty.dto.iot;
+
+import com.BioTy.Planty.entity.IotDevice;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IotDeviceResponseDto {
+    private Long id;
+    private String deviceSerial;
+    private String model;
+    private String status;
+
+    public static IotDeviceResponseDto from(IotDevice device){
+        return IotDeviceResponseDto.builder()
+                .id(device.getId())
+                .deviceSerial(device.getDeviceSerial())
+                .model(device.getModel())
+                .status(device.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/BioTy/Planty/dto/iot/RegisterDeviceRequestDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/iot/RegisterDeviceRequestDto.java
@@ -1,0 +1,8 @@
+package com.BioTy.Planty.dto.iot;
+
+import lombok.Getter;
+
+@Getter
+public class RegisterDeviceRequestDto {
+    private Long iotDeviceId;
+}

--- a/src/main/java/com/BioTy/Planty/dto/plant/PlantInfoDetailResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/plant/PlantInfoDetailResponseDto.java
@@ -1,0 +1,60 @@
+package com.BioTy.Planty.dto.plant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PlantInfoDetailResponseDto {
+    private Long id;
+    private String imageUrl;
+
+    // 기본 정보
+    private String commonName;
+    private String scientificName;
+    private String englishName;
+    private String tradeName;
+    private String familyName;
+    private String origin;
+    private String careTip;
+
+    // 상세 정보
+    private String category;
+    private String growthForm;
+    private Integer growthHeight;
+    private Integer growthWidth;
+    private String indoorGardenUse;
+    private String ecologicalType;
+    private String leafShape;
+    private String leafPattern;
+    private String leafColor;
+
+    private String floweringSeason;
+    private String flowerColor;
+    private String fruitingSeason;
+    private String fruitColor;
+    private String fragrance;
+    private String propagationMethod;
+    private String propagationSeason;
+
+    // 관리 정보
+    private String careLevel;
+    private String careDifficulty;
+    private String lightRequirement;
+    private String placement;
+    private String growthRate;
+    private String optimalTemperature;
+    private String minWinterTemperature;
+    private String humidity;
+    private String fertilizer;
+    private String soilType;
+
+    private String wateringSpring;
+    private String wateringSummer;
+    private String wateringAutumn;
+    private String wateringWinter;
+    private String pestsDiseases;
+
+    // 기능성 정보
+    private String functionalInfo;
+}

--- a/src/main/java/com/BioTy/Planty/dto/plant/PlantInfoListResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/plant/PlantInfoListResponseDto.java
@@ -1,0 +1,13 @@
+package com.BioTy.Planty.dto.plant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PlantInfoListResponseDto {
+    private Long plantInfoId;
+    private String commonName;
+    private String englishName;
+    private String imageUrl;
+}

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/PersonalityResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/PersonalityResponseDto.java
@@ -1,0 +1,14 @@
+package com.BioTy.Planty.dto.userPlant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PersonalityResponseDto {
+    private Long id;
+    private String label;
+    private String emoji;
+    private String description;
+    private String exampleComment;
+}

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantCreateRequestDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantCreateRequestDto.java
@@ -1,0 +1,16 @@
+package com.BioTy.Planty.dto.userPlant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class UserPlantCreateRequestDto {
+    private Long plantInfoId;
+    private String nickname;
+    private LocalDate adoptedAt;
+    private Long personalityId;
+    private String imageUrl;
+}

--- a/src/main/java/com/BioTy/Planty/entity/IotDevice.java
+++ b/src/main/java/com/BioTy/Planty/entity/IotDevice.java
@@ -1,0 +1,27 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "iot_device")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IotDevice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String deviceSerial;
+    private String model;
+    private String status;
+
+    @OneToOne(mappedBy = "iotDevice")
+    private UserPlant userPlant;
+
+    private LocalDateTime lastOnline;
+}

--- a/src/main/java/com/BioTy/Planty/entity/IotDevice.java
+++ b/src/main/java/com/BioTy/Planty/entity/IotDevice.java
@@ -23,5 +23,9 @@ public class IotDevice {
     @OneToOne(mappedBy = "iotDevice")
     private UserPlant userPlant;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     private LocalDateTime lastOnline;
 }

--- a/src/main/java/com/BioTy/Planty/entity/Personality.java
+++ b/src/main/java/com/BioTy/Planty/entity/Personality.java
@@ -19,6 +19,8 @@ public class Personality {
     private String label;
     private String emoji;
     private String color;
+    private String description;
+    private String exampleComment;
 
     public Personality(String label, String emoji, String color){
         this.label = label;

--- a/src/main/java/com/BioTy/Planty/entity/PlantInfo.java
+++ b/src/main/java/com/BioTy/Planty/entity/PlantInfo.java
@@ -1,0 +1,67 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "plant_info")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlantInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String imageUrl;
+
+    // 기본 정보
+    private String commonName;
+    private String scientificName;
+    private String englishName;
+    private String tradeName;
+    private String familyName;
+    private String origin;
+    private String careTip;
+
+    // 상세 정보
+    private String category;
+    private String growthForm;
+    private Integer growthHeight;
+    private Integer growthWidth;
+    private String indoorGardenUse;
+    private String ecologicalType;
+    private String leafShape;
+    private String leafPattern;
+    private String leafColor;
+
+    private String floweringSeason;
+    private String flowerColor;
+    private String fruitingSeason;
+    private String fruitColor;
+    private String fragrance;
+    private String propagationMethod;
+    private String propagationSeason;
+
+    // 관리 정보
+    private String careLevel;
+    private String careDifficulty;
+    private String lightRequirement;
+    private String placement;
+    private String growthRate;
+    private String optimalTemperature;
+    private String minWinterTemperature;
+    private String humidity;
+    private String fertilizer;
+    private String soilType;
+
+    private String wateringSpring;
+    private String wateringSummer;
+    private String wateringAutumn;
+    private String wateringWinter;
+    private String pestsDiseases;
+
+    // 기능성 정보
+    private String functionalInfo;
+}

--- a/src/main/java/com/BioTy/Planty/entity/PlantStatus.java
+++ b/src/main/java/com/BioTy/Planty/entity/PlantStatus.java
@@ -27,7 +27,7 @@ public class PlantStatus {
     private LocalDateTime checkedAt;
 
     public PlantStatus(UserPlant userPlant, Integer temperatureScore, Integer humidityScore,
-                       Integer lightScore, Integer waterScore, String statusMessage, LocalDateTime checkedAt) {
+                       Integer lightScore, String statusMessage, LocalDateTime checkedAt) {
         this.userPlant = userPlant;
         this.temperatureScore = temperatureScore;
         this.lightScore = lightScore;

--- a/src/main/java/com/BioTy/Planty/entity/UserPlant.java
+++ b/src/main/java/com/BioTy/Planty/entity/UserPlant.java
@@ -38,6 +38,10 @@ public class UserPlant {
     @OneToMany(mappedBy = "userPlant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlantStatus> statuses = new ArrayList<>();
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "iot_device_id")
+    private IotDevice iotDevice;
+
     public PlantStatus getLatestStatus(){
         return statuses.stream()
                 .max(Comparator.comparing(PlantStatus::getCheckedAt))
@@ -52,5 +56,9 @@ public class UserPlant {
         this.adoptedAt = adoptedAt;
         this.personality = personality;
         this.plantInfo = plantInfo;
+    }
+
+    public void setIotDevice(IotDevice iotDevice){
+        this.iotDevice = iotDevice;
     }
 }

--- a/src/main/java/com/BioTy/Planty/entity/UserPlant.java
+++ b/src/main/java/com/BioTy/Planty/entity/UserPlant.java
@@ -2,6 +2,7 @@ package com.BioTy.Planty.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,6 +31,10 @@ public class UserPlant {
     @JoinColumn(name = "personality_id", nullable = false)
     private Personality personality;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plant_info_id", nullable = false)
+    private PlantInfo plantInfo;
+
     @OneToMany(mappedBy = "userPlant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlantStatus> statuses = new ArrayList<>();
 
@@ -39,11 +44,13 @@ public class UserPlant {
                 .orElse(null);
     }
 
-    public UserPlant(User user, String nickname, String imageUrl, LocalDate adoptedAt, Personality personality){
+    @Builder
+    public UserPlant(User user, String nickname, String imageUrl, LocalDate adoptedAt, Personality personality, PlantInfo plantInfo){
         this.user = user;
         this.nickname = nickname;
         this.imageUrl = imageUrl;
         this.adoptedAt = adoptedAt;
         this.personality = personality;
+        this.plantInfo = plantInfo;
     }
 }

--- a/src/main/java/com/BioTy/Planty/repository/IotDeviceRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/IotDeviceRepository.java
@@ -4,6 +4,9 @@ import com.BioTy.Planty.entity.IotDevice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface IotDeviceRepository extends JpaRepository<IotDevice, Long> {
+    List<IotDevice> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/BioTy/Planty/repository/IotDeviceRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/IotDeviceRepository.java
@@ -1,0 +1,9 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.IotDevice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IotDeviceRepository extends JpaRepository<IotDevice, Long> {
+}

--- a/src/main/java/com/BioTy/Planty/repository/PersonalityRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/PersonalityRepository.java
@@ -1,0 +1,9 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.Personality;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PersonalityRepository extends JpaRepository<Personality, Long> {
+}

--- a/src/main/java/com/BioTy/Planty/repository/PlantInfoRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/PlantInfoRepository.java
@@ -1,0 +1,10 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.PlantInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlantInfoRepository extends JpaRepository<PlantInfo, Long> {
+
+}

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
@@ -17,7 +17,7 @@ public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
     @Override
     public List<UserPlantSummaryResponseDto> findSummaryDtoByUserId(Long userId) {
         String sql = """
-            SELECT 
+            SELECT\s
               up.id AS userPlantId,
               up.nickname,
               up.image_url AS imageUrl,
@@ -32,12 +32,12 @@ public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
             FROM user_plant up
             LEFT JOIN personality p ON up.personality_id = p.id
             LEFT JOIN plant_status ps ON ps.user_plant_id = up.id
+                AND ps.checked_at = (
+                    SELECT MAX(inner_ps.checked_at)
+                    FROM plant_status inner_ps
+                    WHERE inner_ps.user_plant_id = up.id
+                )
             WHERE up.user_id = ?1
-              AND ps.checked_at = (
-                  SELECT MAX(inner_ps.checked_at)
-                  FROM plant_status inner_ps
-                  WHERE inner_ps.user_plant_id = up.id
-              )
         """;
 
         List<Object[]> rows = em.createNativeQuery(sql)

--- a/src/main/java/com/BioTy/Planty/service/IotDeviceService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotDeviceService.java
@@ -1,0 +1,18 @@
+package com.BioTy.Planty.service;
+
+import com.BioTy.Planty.entity.IotDevice;
+import com.BioTy.Planty.repository.IotDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class IotDeviceService {
+    private final IotDeviceRepository iotDeviceRepository;
+
+    public List<IotDevice> getDevicesByUserId(Long userId){
+        return iotDeviceRepository.findAllByUserId(userId);
+    }
+}

--- a/src/main/java/com/BioTy/Planty/service/PlantInfoService.java
+++ b/src/main/java/com/BioTy/Planty/service/PlantInfoService.java
@@ -1,5 +1,6 @@
 package com.BioTy.Planty.service;
 
+import com.BioTy.Planty.dto.plant.PlantInfoDetailResponseDto;
 import com.BioTy.Planty.dto.plant.PlantInfoListResponseDto;
 import com.BioTy.Planty.entity.PlantInfo;
 import com.BioTy.Planty.repository.PlantInfoRepository;
@@ -13,7 +14,7 @@ import java.util.List;
 public class PlantInfoService {
     private final PlantInfoRepository plantInfoRepository;
 
-    // 전체 식물 목록(도감) 불러오기 메서드
+    // 전체 식물 목록 조회 (식물 도감)
     public List<PlantInfoListResponseDto> getAllPlantInfoLists(){
         List<PlantInfo> plantInfos = plantInfoRepository.findAll();
         return plantInfos.stream()
@@ -24,5 +25,61 @@ public class PlantInfoService {
                         p.getImageUrl()
                 ))
                 .toList();
+    }
+
+    // 식물 상세 정보 조회
+    public PlantInfoDetailResponseDto getPlantInfoDetail(Long plantId){
+        PlantInfo plant = plantInfoRepository.findById(plantId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 식물이 존재하지 않습니다."));
+
+        return new PlantInfoDetailResponseDto(
+                plant.getId(),
+                plant.getImageUrl(),
+
+                plant.getCommonName(),
+                plant.getScientificName(),
+                plant.getEnglishName(),
+                plant.getTradeName(),
+                plant.getFamilyName(),
+                plant.getOrigin(),
+                plant.getCareTip(),
+
+                plant.getCategory(),
+                plant.getGrowthForm(),
+                plant.getGrowthHeight(),
+                plant.getGrowthWidth(),
+                plant.getIndoorGardenUse(),
+                plant.getEcologicalType(),
+                plant.getLeafShape(),
+                plant.getLeafPattern(),
+                plant.getLeafColor(),
+
+                plant.getFloweringSeason(),
+                plant.getFlowerColor(),
+                plant.getFruitingSeason(),
+                plant.getFruitColor(),
+                plant.getFragrance(),
+                plant.getPropagationMethod(),
+                plant.getPropagationSeason(),
+
+                plant.getCareLevel(),
+                plant.getCareDifficulty(),
+                plant.getLightRequirement(),
+                plant.getPlacement(),
+                plant.getGrowthRate(),
+                plant.getOptimalTemperature(),
+                plant.getMinWinterTemperature(),
+                plant.getHumidity(),
+                plant.getFertilizer(),
+                plant.getSoilType(),
+
+                plant.getWateringSpring(),
+                plant.getWateringSummer(),
+                plant.getWateringAutumn(),
+                plant.getWateringWinter(),
+                plant.getPestsDiseases(),
+
+                plant.getFunctionalInfo()
+        );
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/PlantInfoService.java
+++ b/src/main/java/com/BioTy/Planty/service/PlantInfoService.java
@@ -1,0 +1,28 @@
+package com.BioTy.Planty.service;
+
+import com.BioTy.Planty.dto.plant.PlantInfoListResponseDto;
+import com.BioTy.Planty.entity.PlantInfo;
+import com.BioTy.Planty.repository.PlantInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlantInfoService {
+    private final PlantInfoRepository plantInfoRepository;
+
+    // 전체 식물 목록(도감) 불러오기 메서드
+    public List<PlantInfoListResponseDto> getAllPlantInfoLists(){
+        List<PlantInfo> plantInfos = plantInfoRepository.findAll();
+        return plantInfos.stream()
+                .map(p -> new PlantInfoListResponseDto(
+                        p.getId(),
+                        p.getCommonName(),
+                        p.getEnglishName(),
+                        p.getImageUrl()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/BioTy/Planty/service/UserPlantService.java
+++ b/src/main/java/com/BioTy/Planty/service/UserPlantService.java
@@ -1,5 +1,6 @@
 package com.BioTy.Planty.service;
 
+import com.BioTy.Planty.dto.userPlant.PersonalityResponseDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantCreateRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 import com.BioTy.Planty.entity.Personality;
@@ -24,10 +25,12 @@ public class UserPlantService {
     private final PlantInfoRepository plantInfoRepository;
     private final PersonalityRepository personalityRepository;
 
+    // 사용자 반려식물 목록 조회
     public List<UserPlantSummaryResponseDto> getUserPlants(Long userId){
         return userPlantRepository.findSummaryDtoByUserId(userId);
     }
 
+    // 반려식물 등록
     @Transactional
     public Long registerUserPlant(UserPlantCreateRequestDto requestDto, Long userId){
         User user = userRepository.findById(userId)
@@ -48,5 +51,18 @@ public class UserPlantService {
 
         userPlantRepository.save(userPlant);
         return userPlant.getId();
+    }
+
+    // 성격 조회
+    public List<PersonalityResponseDto> getAllPersonalities(){
+        return personalityRepository.findAll().stream()
+                .map(p -> new PersonalityResponseDto(
+                        p.getId(),
+                        p.getLabel(),
+                        p.getEmoji(),
+                        p.getDescription(),
+                        p.getExampleComment()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/UserPlantService.java
+++ b/src/main/java/com/BioTy/Planty/service/UserPlantService.java
@@ -1,7 +1,16 @@
 package com.BioTy.Planty.service;
 
+import com.BioTy.Planty.dto.userPlant.UserPlantCreateRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
+import com.BioTy.Planty.entity.Personality;
+import com.BioTy.Planty.entity.PlantInfo;
+import com.BioTy.Planty.entity.User;
+import com.BioTy.Planty.entity.UserPlant;
+import com.BioTy.Planty.repository.PersonalityRepository;
+import com.BioTy.Planty.repository.PlantInfoRepository;
 import com.BioTy.Planty.repository.UserPlantRepository;
+import com.BioTy.Planty.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,8 +20,33 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserPlantService {
     private final UserPlantRepository userPlantRepository;
+    private final UserRepository userRepository;
+    private final PlantInfoRepository plantInfoRepository;
+    private final PersonalityRepository personalityRepository;
 
     public List<UserPlantSummaryResponseDto> getUserPlants(Long userId){
         return userPlantRepository.findSummaryDtoByUserId(userId);
+    }
+
+    @Transactional
+    public Long registerUserPlant(UserPlantCreateRequestDto requestDto, Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        PlantInfo plantInfo = plantInfoRepository.findById(requestDto.getPlantInfoId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 식물입니다."));
+        Personality personality = personalityRepository.findById(requestDto.getPersonalityId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성격입니다."));
+
+        UserPlant userPlant = UserPlant.builder()
+                .user(user)
+                .nickname(requestDto.getNickname())
+                .imageUrl(requestDto.getImageUrl())
+                .adoptedAt(requestDto.getAdoptedAt())
+                .personality(personality)
+                .plantInfo(plantInfo)
+                .build();
+
+        userPlantRepository.save(userPlant);
+        return userPlant.getId();
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/UserPlantService.java
+++ b/src/main/java/com/BioTy/Planty/service/UserPlantService.java
@@ -3,14 +3,8 @@ package com.BioTy.Planty.service;
 import com.BioTy.Planty.dto.userPlant.PersonalityResponseDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantCreateRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
-import com.BioTy.Planty.entity.Personality;
-import com.BioTy.Planty.entity.PlantInfo;
-import com.BioTy.Planty.entity.User;
-import com.BioTy.Planty.entity.UserPlant;
-import com.BioTy.Planty.repository.PersonalityRepository;
-import com.BioTy.Planty.repository.PlantInfoRepository;
-import com.BioTy.Planty.repository.UserPlantRepository;
-import com.BioTy.Planty.repository.UserRepository;
+import com.BioTy.Planty.entity.*;
+import com.BioTy.Planty.repository.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +18,7 @@ public class UserPlantService {
     private final UserRepository userRepository;
     private final PlantInfoRepository plantInfoRepository;
     private final PersonalityRepository personalityRepository;
+    private final IotDeviceRepository iotDeviceRepository;
 
     // 사용자 반려식물 목록 조회
     public List<UserPlantSummaryResponseDto> getUserPlants(Long userId){
@@ -64,5 +59,16 @@ public class UserPlantService {
                         p.getExampleComment()
                 ))
                 .toList();
+    }
+
+    // 반려식물에 IoT 기기 등록
+    @Transactional
+    public void registerDevice(Long userPlantId, Long iotDeviceId){
+        UserPlant userPlant = userPlantRepository.findById(userPlantId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 반려식물이 존재하지 않습니다."));
+        IotDevice iotDevice = iotDeviceRepository.findById(iotDeviceId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 IoT 기기가 존재하지 않습니다."));
+
+        userPlant.setIotDevice(iotDevice);
     }
 }


### PR DESCRIPTION
### Pull Request
식물 등록 flow 구현

**🪾작업한 브랜치**
- feat/# 4-register-plant

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-BE/issues/4
- https://github.com/Team-BIoTy/Planty-FE/issues/3

**🔥 작업 내용**

- 반려식물 등록 Flow 구현 완료
1. 식물 도감 목록 조회 API (`GET /plants`)
2. 도감 상세 정보 조회 API (`GET /plants/{plantId}`)
3. 반려식물 등록 API (`POST /user-plants`)
4. 식물 성격 목록 조회 API (`GET /personalities`)
5. 사용자 IoT 기기 목록 조회 API (`GET /iot-devices`)
6. IoT 기기 연결 API (`POST /user-plants/{userPlantId}/device`)

- 각 단계별 DTO, Entity, Repository, Service, Controller 계층 완성
- Swagger 문서화 및 Flutter 연동 테스트 완료
- 반려식물 상태(status) 없는 경우에도 목록 조회 가능하도록 쿼리 수정 
→ checked_at이 없는 row까지 포함하는 조건 추가 ([커밋](https://github.com/Team-BIoTy/Planty-BE/commit/43db07ae5fd3a99cee285d35481e6c4f3025dcdb))



**🚀 추후 고려사항 (성능 개선 & 확장성)**

- 등록된 반려식물에 대해 초기 상태 자동 생성 여부 검토
- IoT 기기 중복 연결 방지 로직 추가
- 식물 등록 프로세스 중 예외 케이스 대응 (ex. 없는 plantId, personalityId 등)
- 등록 완료 후 홈화면 자동 갱신 방식 개선
