### PR TITLE
[Feat] #5 반려식물 상세 리포트

### DIFF
--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
                                 "/auth/login",
                                 "/auth/validate",
                                 "/user-plants",
+                                "/user-plants/{userPlantId}",
                                 "/user-plants/{userPlantId}/device",
                                 "/personalities",
                                 "/plants",

--- a/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
+++ b/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
@@ -2,6 +2,7 @@ package com.BioTy.Planty.controller;
 
 import com.BioTy.Planty.dto.iot.RegisterDeviceRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantCreateRequestDto;
+import com.BioTy.Planty.dto.userPlant.UserPlantDetailResponseDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 import com.BioTy.Planty.service.AuthService;
 import com.BioTy.Planty.service.UserPlantService;
@@ -70,5 +71,14 @@ public class UserPlantController {
     ){
         userPlantService.registerDevice(userPlantId, requestDto.getIotDeviceId());
         return ResponseEntity.ok().build();
+    }
+
+    // 반려식물 상세 정보 조회
+    @Operation(
+            summary = "반려식물 상세 조회",
+            description = "userPlantId를 이용해 반려식물의 상세 정보를 조회합니다.")
+    @GetMapping("/{userPlantId}")
+    public UserPlantDetailResponseDto getUserPlantDetail(@PathVariable Long userPlantId) {
+        return userPlantService.getUserPlantDetail(userPlantId);
     }
 }

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/PersonalityResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/PersonalityResponseDto.java
@@ -9,6 +9,7 @@ public class PersonalityResponseDto {
     private Long id;
     private String label;
     private String emoji;
+    private String color;
     private String description;
     private String exampleComment;
 }

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantDetailResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantDetailResponseDto.java
@@ -1,0 +1,21 @@
+package com.BioTy.Planty.dto.userPlant;
+
+import com.BioTy.Planty.dto.plant.PlantInfoDetailResponseDto;
+import com.BioTy.Planty.dto.userPlant.detail.DetailEnvStandardDto;
+import com.BioTy.Planty.dto.userPlant.detail.DetailSensorDto;
+import com.BioTy.Planty.dto.userPlant.detail.DetailStatusDto;
+
+import java.time.LocalDate;
+
+public class UserPlantDetailResponseDto {
+    private Long id; // userPlant id
+    private String nickname;
+    private String imageUrl;
+    private LocalDate adoptedAt;
+
+    private PersonalityResponseDto personality; // 성격
+    private PlantInfoDetailResponseDto plantInfo; // 도감 정보
+    private DetailEnvStandardDto envStandard; // 환경 기준 (min, max값)
+    private DetailSensorDto sensorData; // 최신 센서 데이터
+    private DetailStatusDto status; // 최신 상태 (0~3점, 상태 메시지)
+}

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantDetailResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantDetailResponseDto.java
@@ -4,9 +4,11 @@ import com.BioTy.Planty.dto.plant.PlantInfoDetailResponseDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailEnvStandardDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailSensorDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailStatusDto;
+import lombok.Getter;
 
 import java.time.LocalDate;
 
+@Getter
 public class UserPlantDetailResponseDto {
     private Long id; // userPlant id
     private String nickname;
@@ -18,4 +20,19 @@ public class UserPlantDetailResponseDto {
     private DetailEnvStandardDto envStandard; // 환경 기준 (min, max값)
     private DetailSensorDto sensorData; // 최신 센서 데이터
     private DetailStatusDto status; // 최신 상태 (0~3점, 상태 메시지)
+
+    public UserPlantDetailResponseDto(long id, String nickname, String imageUrl, LocalDate adoptedAt,
+                                      PersonalityResponseDto personality, PlantInfoDetailResponseDto plantInfo,
+                                      DetailEnvStandardDto envStandard, DetailStatusDto status, DetailSensorDto sensorData) {
+        this.id = id;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+        this.adoptedAt = adoptedAt;
+        this.personality = personality;
+        this.plantInfo = plantInfo;
+        this.envStandard = envStandard;
+        this.status = status;
+        this.sensorData = sensorData;
+    }
+
 }

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/detail/DetailEnvStandardDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/detail/DetailEnvStandardDto.java
@@ -1,0 +1,20 @@
+package com.BioTy.Planty.dto.userPlant.detail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DetailEnvStandardDto {
+    private Range temperature;
+    private Range light;
+    private Range humidity;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Range{
+        private Integer min;
+        private Integer max;
+    }
+
+}

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/detail/DetailSensorDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/detail/DetailSensorDto.java
@@ -1,0 +1,16 @@
+package com.BioTy.Planty.dto.userPlant.detail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class DetailSensorDto {
+    private BigDecimal temperature;
+    private BigDecimal humidity;
+    private BigDecimal light;
+    private LocalDateTime recordedAt;
+}

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/detail/DetailStatusDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/detail/DetailStatusDto.java
@@ -1,0 +1,16 @@
+package com.BioTy.Planty.dto.userPlant.detail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class DetailStatusDto {
+    private Integer temperatureScore; // 온도 점수 (0~3)
+    private Integer lightScore; // 조도 점수 (0~3)
+    private Integer humidityScore; // 습도 점수 (0~3)
+    private String statusMessage;
+    private LocalDateTime checkedAt;
+}

--- a/src/main/java/com/BioTy/Planty/entity/PlantEnvStandards.java
+++ b/src/main/java/com/BioTy/Planty/entity/PlantEnvStandards.java
@@ -1,0 +1,30 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlantEnvStandards {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 식물의 기준인지
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plant_info_id", nullable = false)
+    private PlantInfo plantInfo;
+
+    private Integer minTemperature;
+    private Integer maxTemperature;
+
+    private Integer minHumidity;
+    private Integer maxHumidity;
+
+    private Integer minLight;
+    private Integer maxLight;
+}

--- a/src/main/java/com/BioTy/Planty/entity/SensorLogs.java
+++ b/src/main/java/com/BioTy/Planty/entity/SensorLogs.java
@@ -1,0 +1,28 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SensorLogs {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "device_id", nullable = false)
+    private IotDevice iotDevice;
+
+    private BigDecimal temperature;
+    private BigDecimal humidity;
+    private BigDecimal light;
+
+    private LocalDateTime recordedAt;
+}

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryCustom.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.BioTy.Planty.repository;
 
+import com.BioTy.Planty.dto.userPlant.UserPlantDetailResponseDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 
 import java.util.List;
 
 public interface UserPlantRepositoryCustom {
     List<UserPlantSummaryResponseDto> findSummaryDtoByUserId(Long userId);
+    UserPlantDetailResponseDto findDetailDtoByUserPlantId(Long userPlantId);
+
 }

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
@@ -1,11 +1,19 @@
 package com.BioTy.Planty.repository;
 
+import com.BioTy.Planty.dto.plant.PlantInfoDetailResponseDto;
+import com.BioTy.Planty.dto.userPlant.PersonalityResponseDto;
+import com.BioTy.Planty.dto.userPlant.UserPlantDetailResponseDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
+import com.BioTy.Planty.dto.userPlant.detail.DetailEnvStandardDto;
+import com.BioTy.Planty.dto.userPlant.detail.DetailSensorDto;
+import com.BioTy.Planty.dto.userPlant.detail.DetailStatusDto;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 
 @Repository
@@ -61,5 +69,184 @@ public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
                         (String) row[10]
                 )
         )).toList();
+    }
+
+    @Override
+    public UserPlantDetailResponseDto findDetailDtoByUserPlantId(Long userPlantId) {
+        String sql = """
+            SELECT
+              -- UserPlant
+              up.id, up.nickname, up.image_url, up.adopted_at,
+
+              -- Personality
+              p.id, p.label, p.emoji, p.color, p.description, p.example_comment,
+
+              -- PlantInfo
+              pi.id, pi.image_url, pi.common_name, pi.scientific_name, pi.english_name, pi.trade_name,
+              pi.family_name, pi.origin, pi.care_tip, pi.category, pi.growth_form,
+              pi.growth_height, pi.growth_width, pi.indoor_garden_use, pi.ecological_type,
+              pi.leaf_shape, pi.leaf_pattern, pi.leaf_color, pi.flowering_season, pi.flower_color,
+              pi.fruiting_season, pi.fruit_color, pi.fragrance, pi.propagation_method, pi.propagation_season,
+              pi.care_level, pi.care_difficulty, pi.light_requirement, pi.placement, pi.growth_rate,
+              pi.optimal_temperature, pi.min_winter_temperature, pi.humidity, pi.fertilizer, pi.soil_type,
+              pi.watering_spring, pi.watering_summer, pi.watering_autumn, pi.watering_winter,
+              pi.pests_diseases, pi.functional_info,
+
+              -- PlantEnvStandards
+              pes.min_temperature, pes.max_temperature,
+              pes.min_humidity, pes.max_humidity,
+              pes.min_light, pes.max_light,
+
+              -- PlantStatus (latest)
+              ps.temperature_score, ps.light_score, ps.humidity_score, ps.status_message, ps.checked_at,
+
+              -- SensorLogs (latest)
+              sl.temperature, sl.humidity, sl.light, sl.recorded_at
+
+            FROM user_plant up
+            LEFT JOIN personality p ON up.personality_id = p.id
+            LEFT JOIN plant_info pi ON up.plant_info_id = pi.id
+            LEFT JOIN plant_env_standards pes ON pi.id = pes.plant_info_id
+            LEFT JOIN iot_device id ON id.id = up.iot_device_id
+            LEFT JOIN (
+                SELECT ps1.*
+                FROM plant_status ps1
+                WHERE ps1.user_plant_id = ?1
+                ORDER BY ps1.checked_at DESC
+                LIMIT 1
+            ) ps ON ps.user_plant_id = up.id
+            LEFT JOIN (
+                SELECT sl1.*
+                FROM sensor_logs sl1
+                ORDER BY sl1.recorded_at DESC
+            ) sl ON sl.device_id = id.id
+            WHERE up.id = ?1
+        """;
+
+        Object[] result = (Object[]) em.createNativeQuery(sql)
+                .setParameter(1, userPlantId)
+                .getSingleResult();
+
+        int idx = 0;
+
+        // --- 기본 정보 매핑
+        Long userPlantIdRes = ((Number) result[idx++]).longValue();
+        String nickname = (String) result[idx++];
+        String imageUrl = (String) result[idx++];
+        var adoptedAt = ((java.sql.Date) result[idx++]).toLocalDate();
+
+        // --- Personality 매핑
+        PersonalityResponseDto personality = new PersonalityResponseDto(
+                ((Number) result[idx++]).longValue(),
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++]
+        );
+
+        // --- PlantInfo 매핑
+        PlantInfoDetailResponseDto plantInfo = new PlantInfoDetailResponseDto(
+                ((Number) result[idx++]).longValue(),
+                (String) result[idx++],
+
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+
+                (String) result[idx++],
+                (String) result[idx++],
+                (Integer) result[idx++],
+                (Integer) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+                (String) result[idx++],
+
+                (String) result[idx++]
+        );
+
+        // --- 환경 기준 매핑
+        DetailEnvStandardDto envStandard = new DetailEnvStandardDto(
+                new DetailEnvStandardDto.Range((Integer) result[idx++], (Integer) result[idx++]),
+                new DetailEnvStandardDto.Range((Integer) result[idx++], (Integer) result[idx++]),
+                new DetailEnvStandardDto.Range((Integer) result[idx++], (Integer) result[idx++])
+        );
+
+        // --- Status 매핑
+        Integer tempScore = (Integer) result[idx++];
+        Integer lightScore = (Integer) result[idx++];
+        Integer humidityScore = (Integer) result[idx++];
+        String statusMessage = (String) result[idx++];
+        java.sql.Timestamp checkedAt = (java.sql.Timestamp) result[idx++];
+
+        DetailStatusDto statusDto = (tempScore != null || lightScore != null || humidityScore != null || statusMessage != null || checkedAt != null)
+                ? new DetailStatusDto(
+                tempScore,
+                lightScore,
+                humidityScore,
+                statusMessage,
+                checkedAt != null ? checkedAt.toLocalDateTime() : null
+        )
+                : null;
+
+        // --- Sensor 매핑
+        BigDecimal sensorTemp = (BigDecimal) result[idx++];
+        BigDecimal sensorHumidity = (BigDecimal) result[idx++];
+        BigDecimal sensorLight = (BigDecimal) result[idx++];
+        java.sql.Timestamp sensorRecordedAt = (java.sql.Timestamp) result[idx++];
+
+        DetailSensorDto sensorDto = (sensorTemp != null || sensorHumidity != null || sensorLight != null || sensorRecordedAt != null)
+                ? new DetailSensorDto(
+                sensorTemp,
+                sensorHumidity,
+                sensorLight,
+                sensorRecordedAt != null ? sensorRecordedAt.toLocalDateTime() : null
+        )
+                : null;
+
+        // --- 최종 조립
+        return new UserPlantDetailResponseDto(
+                userPlantIdRes,
+                nickname,
+                imageUrl,
+                adoptedAt,
+                personality,
+                plantInfo,
+                envStandard,
+                statusDto,
+                sensorDto
+        );
+
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/UserPlantService.java
+++ b/src/main/java/com/BioTy/Planty/service/UserPlantService.java
@@ -2,6 +2,7 @@ package com.BioTy.Planty.service;
 
 import com.BioTy.Planty.dto.userPlant.PersonalityResponseDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantCreateRequestDto;
+import com.BioTy.Planty.dto.userPlant.UserPlantDetailResponseDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 import com.BioTy.Planty.entity.*;
 import com.BioTy.Planty.repository.*;
@@ -71,5 +72,11 @@ public class UserPlantService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 IoT 기기가 존재하지 않습니다."));
 
         userPlant.setIotDevice(iotDevice);
+    }
+
+    // 반려식물 상세 정보 조회
+    @Transactional
+    public UserPlantDetailResponseDto getUserPlantDetail(Long userPlantId) {
+        return userPlantRepository.findDetailDtoByUserPlantId(userPlantId);
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/UserPlantService.java
+++ b/src/main/java/com/BioTy/Planty/service/UserPlantService.java
@@ -55,6 +55,7 @@ public class UserPlantService {
                         p.getId(),
                         p.getLabel(),
                         p.getEmoji(),
+                        p.getColor(),
                         p.getDescription(),
                         p.getExampleComment()
                 ))


### PR DESCRIPTION
### Pull Request
반려식물 상세 페이지 조회 기능 구현

**🪾작업한 브랜치**
- feat/# 5-user-plant-detail

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-BE/issues/5
- https://github.com/Team-BIoTy/Planty-FE/issues/4

**🔥 작업 내용**
- UserPlantDetailResponseDto 생성
- 상세 정보를 위한 서브 DTO 구성 (DetailEnvStandard, DetailStatus, DetailSensor)
- 기존 PlantInfoDto, PersonalityDto 재사용
- SensorLogs, PlantEnvStandards 엔티티 추가 및 구조 설계
- UserPlantRepositoryImpl에서 NativeQuery로 전체 데이터 조인
- 최신 상태 (plant_status), 최신 센서 데이터 (sensor_logs)만 조회되도록 최적화
- Service 레이어에서 데이터 조합 및 변환 로직 구현
- Controller 레이어에서 GET /user-plants/{userPlantId} 엔드포인트 구현
- Swagger 테스트 및 프론트 연동 완료

**🚀 추후 고려사항 (성능 개선 & 확장성)**
1. 상태/센서 기준값 비교를 통한 Score 산정 로직 추가 예정
2. 도감/성격의 변동 가능성을 고려한 캐싱 전략 필요