### PR TITLE
[Feat] #7 iot 센서 기반 자동 제어 로직 구현

### DIFF
--- a/src/main/java/com/BioTy/Planty/PlantyApplication.java
+++ b/src/main/java/com/BioTy/Planty/PlantyApplication.java
@@ -3,7 +3,9 @@ package com.BioTy.Planty;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class PlantyApplication {

--- a/src/main/java/com/BioTy/Planty/config/AdafruitClient.java
+++ b/src/main/java/com/BioTy/Planty/config/AdafruitClient.java
@@ -26,7 +26,7 @@ public class AdafruitClient {
     private final RestTemplate restTemplate;
 
     public void sendCommand(String feedKey){
-        String url = String.format("%s/api/v2/%s/feeds/%s", baseUrl, username, feedKey);
+        String url = String.format("%s/api/v2/%s/feeds/%s/data", baseUrl, username, feedKey);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/BioTy/Planty/config/AdafruitClient.java
+++ b/src/main/java/com/BioTy/Planty/config/AdafruitClient.java
@@ -1,14 +1,17 @@
 package com.BioTy.Planty.config;
 
+import com.BioTy.Planty.dto.iot.SensorLogResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -24,6 +27,16 @@ public class AdafruitClient {
     private String apiKey;
 
     private final RestTemplate restTemplate;
+
+    public SensorLogResponseDto fetchFeedInfo(String feedKey){
+        String url = String.format("%s/api/v2/%s/feeds/%s", baseUrl, username, feedKey);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-AIO-Key", apiKey);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        return restTemplate.exchange(url, HttpMethod.GET, request, SensorLogResponseDto.class).getBody();
+    }
 
     public void sendCommand(String feedKey){
         String url = String.format("%s/api/v2/%s/feeds/%s/data", baseUrl, username, feedKey);

--- a/src/main/java/com/BioTy/Planty/config/AdafruitClient.java
+++ b/src/main/java/com/BioTy/Planty/config/AdafruitClient.java
@@ -1,0 +1,41 @@
+package com.BioTy.Planty.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AdafruitClient {
+
+    @Value("${adafruit.api.url}")
+    private String baseUrl;
+
+    @Value("${adafruit.api.username}")
+    private String username;
+
+    @Value("${adafruit.api.key}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate;
+
+    public void sendCommand(String feedKey){
+        String url = String.format("%s/api/v2/%s/feeds/%s", baseUrl, username, feedKey);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("X-AIO-Key", apiKey);
+
+        Map<String, String> body = Map.of("value", "ON");
+
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(body, headers);
+        restTemplate.postForEntity(url, request, String.class);
+    }
+
+}

--- a/src/main/java/com/BioTy/Planty/config/AppConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/AppConfig.java
@@ -1,0 +1,13 @@
+package com.BioTy.Planty.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
                                 "/personalities",
                                 "/plants",
                                 "/plants/{plnatId}",
-                                "/iot-devices",
+                                "/iot",
                                 "/chats",
                                 "/chats/{chatRoomId}",
                                 "/chats/{chatRoomId}/messages",

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -18,19 +18,12 @@ public class SecurityConfig {
                 .csrf().disable()
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/auth/signup",
-                                "/auth/login",
-                                "/auth/validate",
-                                "/user-plants",
-                                "/user-plants/{userPlantId}",
-                                "/user-plants/{userPlantId}/device",
+                                "/auth/**",
+                                "/user-plants/**",
                                 "/personalities",
-                                "/plants",
-                                "/plants/{plnatId}",
-                                "/iot",
-                                "/chats",
-                                "/chats/{chatRoomId}",
-                                "/chats/{chatRoomId}/messages",
+                                "/plants/**",
+                                "/iot/**",
+                                "/chats/**",
 
                                 // Swagger 경로들
                                 "/swagger-ui/**",

--- a/src/main/java/com/BioTy/Planty/config/SensorFetchScheduler.java
+++ b/src/main/java/com/BioTy/Planty/config/SensorFetchScheduler.java
@@ -1,0 +1,18 @@
+package com.BioTy.Planty.config;
+
+import com.BioTy.Planty.service.IotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SensorFetchScheduler {
+    private final IotService iotService;
+
+    @Scheduled(cron = "0 0 * * * *") // 매시 정각마다
+    public void fetchSensorDataEveryHour() {
+        Long deviceId = 1L;
+        iotService.fetchAndSaveSensorLog(deviceId);
+    }
+}

--- a/src/main/java/com/BioTy/Planty/config/SensorFetchScheduler.java
+++ b/src/main/java/com/BioTy/Planty/config/SensorFetchScheduler.java
@@ -1,6 +1,8 @@
 package com.BioTy.Planty.config;
 
+import com.BioTy.Planty.repository.SensorLogsRepository;
 import com.BioTy.Planty.service.IotService;
+import com.BioTy.Planty.service.PlantStatusService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -9,10 +11,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SensorFetchScheduler {
     private final IotService iotService;
+    private final PlantStatusService plantStatusService;
 
     @Scheduled(cron = "0 0 * * * *") // 매시 정각마다
     public void fetchSensorDataEveryHour() {
         Long deviceId = 1L;
         iotService.fetchAndSaveSensorLog(deviceId);
+        plantStatusService.evaluatePlantStatus(deviceId);
     }
 }

--- a/src/main/java/com/BioTy/Planty/controller/IotController.java
+++ b/src/main/java/com/BioTy/Planty/controller/IotController.java
@@ -11,11 +11,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
 @Tag(name = "Iot", description = "사용자의 IoT 기기 관련 API")
@@ -73,7 +71,7 @@ public class IotController {
         token = token.replace("Bearer ", "");
         Long userId = authService.getUserIdFromToken(token);
 
-        iotService.sendAction(userPlantId, userId, request.getType());
+        iotService.sendCommandToAdafruit(userPlantId, userId, request.getType());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/BioTy/Planty/controller/IotController.java
+++ b/src/main/java/com/BioTy/Planty/controller/IotController.java
@@ -48,6 +48,18 @@ public class IotController {
     }
 
     @Operation(
+            summary = "IoT 센서 데이터 수동 수신",
+            description = "선택한 IoT 기기의 센서 데이터를 Adafruit에서 수신하여 sensor_logs에 저장합니다."
+    )
+    @PostMapping("/sensor-data")
+    public ResponseEntity<Void> fetchSensorData(
+        @RequestParam Long deviceId
+    ){
+        iotService.fetchAndSaveSensorLog(deviceId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
             summary = "IoT 액션 명령 전송",
             description = "선택한 반려식물의 IoT 장치에 명령(WATER, FAN, LIGHT)을 전송합니다.",
             security = @SecurityRequirement(name = "bearerAuth")

--- a/src/main/java/com/BioTy/Planty/controller/IotController.java
+++ b/src/main/java/com/BioTy/Planty/controller/IotController.java
@@ -3,7 +3,7 @@ package com.BioTy.Planty.controller;
 import com.BioTy.Planty.dto.iot.IotDeviceResponseDto;
 import com.BioTy.Planty.entity.IotDevice;
 import com.BioTy.Planty.service.AuthService;
-import com.BioTy.Planty.service.IotDeviceService;
+import com.BioTy.Planty.service.IotService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -18,12 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Tag(name = "IotDevice", description = "사용자의 IoT 기기 API")
+@Tag(name = "Iot", description = "사용자의 IoT 기기 관련 API")
 @RestController
-@RequestMapping("/iot-devices")
+@RequestMapping("/iot")
 @RequiredArgsConstructor
-public class IotDeviceController {
-    private final IotDeviceService iotDeviceService;
+public class IotController {
+    private final IotService iotService;
     private final AuthService authService;
 
     @Operation(
@@ -38,7 +38,7 @@ public class IotDeviceController {
     ) {
         token = token.replace("Bearer ", "");
         Long userId = authService.getUserIdFromToken(token);
-        List<IotDevice> devices = iotDeviceService.getDevicesByUserId(userId);
+        List<IotDevice> devices = iotService.getDevicesByUserId(userId);
 
         List<IotDeviceResponseDto> response = devices.stream()
                 .map(IotDeviceResponseDto::from)

--- a/src/main/java/com/BioTy/Planty/controller/IotController.java
+++ b/src/main/java/com/BioTy/Planty/controller/IotController.java
@@ -1,5 +1,6 @@
 package com.BioTy.Planty.controller;
 
+import com.BioTy.Planty.dto.iot.ActionRequestDto;
 import com.BioTy.Planty.dto.iot.IotDeviceResponseDto;
 import com.BioTy.Planty.entity.IotDevice;
 import com.BioTy.Planty.service.AuthService;
@@ -10,12 +11,11 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
 @Tag(name = "Iot", description = "사용자의 IoT 기기 관련 API")
@@ -45,5 +45,23 @@ public class IotController {
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "IoT 액션 명령 전송",
+            description = "선택한 반려식물의 IoT 장치에 명령(WATER, FAN, LIGHT)을 전송합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/{userPlantId}/actions")
+    public ResponseEntity<Void> sendActionToAdafruit(
+            @Parameter(description = "반려식물 ID") @PathVariable Long userPlantId,
+            @RequestBody ActionRequestDto request,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token
+    ) {
+        token = token.replace("Bearer ", "");
+        Long userId = authService.getUserIdFromToken(token);
+
+        iotService.sendAction(userPlantId, userId, request.getType());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/BioTy/Planty/dto/iot/ActionRequestDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/iot/ActionRequestDto.java
@@ -1,0 +1,12 @@
+package com.BioTy.Planty.dto.iot;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ActionRequestDto {
+    private String type; // "WATER", "FAN", "LIGHT"
+}

--- a/src/main/java/com/BioTy/Planty/dto/iot/SensorLogResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/iot/SensorLogResponseDto.java
@@ -1,0 +1,15 @@
+package com.BioTy.Planty.dto.iot;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class SensorLogResponseDto {
+    private String key;
+
+    @JsonProperty("last_value")
+    private String lastValue;
+
+    @JsonProperty("updated_at")
+    private String updatedAt;
+}

--- a/src/main/java/com/BioTy/Planty/entity/DeviceActionLog.java
+++ b/src/main/java/com/BioTy/Planty/entity/DeviceActionLog.java
@@ -1,0 +1,23 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeviceActionLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private DeviceCommand command;
+
+    private String result; // "success" 또는 "fail"
+    private LocalDateTime executedAt;
+}

--- a/src/main/java/com/BioTy/Planty/entity/DeviceCommand.java
+++ b/src/main/java/com/BioTy/Planty/entity/DeviceCommand.java
@@ -1,0 +1,26 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeviceCommand {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private IotDevice iotDevice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private UserPlant userPlant;
+
+    private String commandType; // WATER, LIGHT, FAN
+    private LocalDateTime sentAt;
+}

--- a/src/main/java/com/BioTy/Planty/entity/PlantStatus.java
+++ b/src/main/java/com/BioTy/Planty/entity/PlantStatus.java
@@ -1,14 +1,14 @@
 package com.BioTy.Planty.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlantStatus {
     @Id

--- a/src/main/java/com/BioTy/Planty/entity/PlantStatus.java
+++ b/src/main/java/com/BioTy/Planty/entity/PlantStatus.java
@@ -26,13 +26,6 @@ public class PlantStatus {
     private String statusMessage;
     private LocalDateTime checkedAt;
 
-    public PlantStatus(UserPlant userPlant, Integer temperatureScore, Integer humidityScore,
-                       Integer lightScore, String statusMessage, LocalDateTime checkedAt) {
-        this.userPlant = userPlant;
-        this.temperatureScore = temperatureScore;
-        this.lightScore = lightScore;
-        this.humidityScore = humidityScore;
-        this.statusMessage = statusMessage;
-        this.checkedAt = checkedAt;
-    }
+    @Column(nullable = false)
+    private boolean actionNeeded = false;
 }

--- a/src/main/java/com/BioTy/Planty/entity/SensorLogs.java
+++ b/src/main/java/com/BioTy/Planty/entity/SensorLogs.java
@@ -25,4 +25,12 @@ public class SensorLogs {
     private BigDecimal light;
 
     private LocalDateTime recordedAt;
+
+    public SensorLogs(IotDevice iotDevice, BigDecimal temperature, BigDecimal humidity, BigDecimal light, LocalDateTime recordedAt) {
+        this.iotDevice = iotDevice;
+        this.temperature = temperature;
+        this.humidity = humidity;
+        this.light = light;
+        this.recordedAt = recordedAt;
+    }
 }

--- a/src/main/java/com/BioTy/Planty/entity/UserPlant.java
+++ b/src/main/java/com/BioTy/Planty/entity/UserPlant.java
@@ -27,6 +27,10 @@ public class UserPlant {
     private String imageUrl;
     private LocalDate adoptedAt;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean autoControlEnabled = true;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "personality_id", nullable = false)
     private Personality personality;
@@ -49,13 +53,15 @@ public class UserPlant {
     }
 
     @Builder
-    public UserPlant(User user, String nickname, String imageUrl, LocalDate adoptedAt, Personality personality, PlantInfo plantInfo){
+    public UserPlant(User user, String nickname, String imageUrl, LocalDate adoptedAt,
+                     Personality personality, PlantInfo plantInfo, boolean autoControlEnabled){
         this.user = user;
         this.nickname = nickname;
         this.imageUrl = imageUrl;
         this.adoptedAt = adoptedAt;
         this.personality = personality;
         this.plantInfo = plantInfo;
+        this.autoControlEnabled = autoControlEnabled;
     }
 
     public void setIotDevice(IotDevice iotDevice){

--- a/src/main/java/com/BioTy/Planty/entity/UserPlant.java
+++ b/src/main/java/com/BioTy/Planty/entity/UserPlant.java
@@ -27,7 +27,6 @@ public class UserPlant {
     private String imageUrl;
     private LocalDate adoptedAt;
 
-    @Builder.Default
     @Column(nullable = false)
     private boolean autoControlEnabled = true;
 

--- a/src/main/java/com/BioTy/Planty/repository/DeviceActionLogRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/DeviceActionLogRepository.java
@@ -1,0 +1,9 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.DeviceActionLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeviceActionLogRepository extends JpaRepository<DeviceActionLog, Long> {
+}

--- a/src/main/java/com/BioTy/Planty/repository/DeviceCommandRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/DeviceCommandRepository.java
@@ -1,0 +1,9 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.DeviceCommand;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeviceCommandRepository extends JpaRepository<DeviceCommand, Long> {
+}

--- a/src/main/java/com/BioTy/Planty/repository/IotRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/IotRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface IotDeviceRepository extends JpaRepository<IotDevice, Long> {
+public interface IotRepository extends JpaRepository<IotDevice, Long> {
     List<IotDevice> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/BioTy/Planty/repository/PlantEnvStandardsRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/PlantEnvStandardsRepository.java
@@ -1,0 +1,13 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.PlantEnvStandards;
+import com.BioTy.Planty.entity.PlantInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PlantEnvStandardsRepository extends JpaRepository<PlantEnvStandards, Long> {
+    Optional<PlantEnvStandards> findByPlantInfo(PlantInfo plantInfo);
+}

--- a/src/main/java/com/BioTy/Planty/repository/PlantStatusRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/PlantStatusRepository.java
@@ -1,0 +1,11 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.PlantStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PlantStatusRepository extends JpaRepository<PlantStatus, Long> {
+}

--- a/src/main/java/com/BioTy/Planty/repository/SensorLogsRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/SensorLogsRepository.java
@@ -1,0 +1,9 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.SensorLogs;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SensorLogsRepository extends JpaRepository<SensorLogs, Long> {
+}

--- a/src/main/java/com/BioTy/Planty/repository/SensorLogsRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/SensorLogsRepository.java
@@ -4,6 +4,9 @@ import com.BioTy.Planty.entity.SensorLogs;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface SensorLogsRepository extends JpaRepository<SensorLogs, Long> {
+    Optional<SensorLogs> findTopByIotDevice_IdOrderByRecordedAtDesc(Long deviceId);
 }

--- a/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
+++ b/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
@@ -1,20 +1,46 @@
 package com.BioTy.Planty.service;
 
+import com.BioTy.Planty.entity.DeviceActionLog;
+import com.BioTy.Planty.entity.DeviceCommand;
 import com.BioTy.Planty.entity.UserPlant;
+import com.BioTy.Planty.repository.DeviceActionLogRepository;
+import com.BioTy.Planty.repository.DeviceCommandRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class DeviceCommandService {
     private final IotService iotService;
+    private final DeviceCommandRepository commandRepository;
+    private final DeviceActionLogRepository actionLogRepository;
 
     public void sendActions(UserPlant userPlant, List<String> actionTypes) {
         for (String action : actionTypes) {
             try {
+                // 1. 명령 전송
                 iotService.sendAction(userPlant.getId(), userPlant.getUser().getId(), action);
+
+                // 2. 전송한 명령 기록 (device_command)
+                DeviceCommand command = DeviceCommand.builder()
+                        .iotDevice(userPlant.getIotDevice())
+                        .userPlant(userPlant)
+                        .commandType(action)
+                        .sentAt(LocalDateTime.now())
+                        .build();
+                commandRepository.save(command);
+
+                // 3. 실행 후 상태 기록 (device_action_log)
+                DeviceActionLog log = DeviceActionLog.builder()
+                        .command(command)
+                        .result("pending")
+                        .build();
+                actionLogRepository.save(log);
+
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
+++ b/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
@@ -6,7 +6,6 @@ import com.BioTy.Planty.entity.UserPlant;
 import com.BioTy.Planty.repository.DeviceActionLogRepository;
 import com.BioTy.Planty.repository.DeviceCommandRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -19,11 +18,11 @@ public class DeviceCommandService {
     private final DeviceCommandRepository commandRepository;
     private final DeviceActionLogRepository actionLogRepository;
 
-    public void sendActions(UserPlant userPlant, List<String> actionTypes) {
+    public void executeCommands(UserPlant userPlant, List<String> actionTypes) {
         for (String action : actionTypes) {
             try {
                 // 1. 명령 전송
-                iotService.sendAction(userPlant.getId(), userPlant.getUser().getId(), action);
+                iotService.sendCommandToAdafruit(userPlant.getId(), userPlant.getUser().getId(), action);
 
                 // 2. 전송한 명령 기록 (device_command)
                 DeviceCommand command = DeviceCommand.builder()

--- a/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
+++ b/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
@@ -1,0 +1,23 @@
+package com.BioTy.Planty.service;
+
+import com.BioTy.Planty.entity.UserPlant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceCommandService {
+    private final IotService iotService;
+
+    public void sendActions(UserPlant userPlant, List<String> actionTypes) {
+        for (String action : actionTypes) {
+            try {
+                iotService.sendAction(userPlant.getId(), userPlant.getUser().getId(), action);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -57,7 +57,7 @@ public class IotService {
                 .withZoneSameInstant(ZoneId.of("Asia/Seoul"))
                 .toLocalDateTime();
 
-        SensorLogs logs = new SensorLogs(device,lightVal, temperatureVal, humidityVal, recordedAt);
+        SensorLogs logs = new SensorLogs(device, temperatureVal, humidityVal, lightVal, recordedAt);
         sensorLogsRepository.save(logs);
     }
 

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -1,14 +1,24 @@
 package com.BioTy.Planty.service;
 
 import com.BioTy.Planty.config.AdafruitClient;
+import com.BioTy.Planty.dto.iot.SensorLogResponseDto;
 import com.BioTy.Planty.entity.IotDevice;
+import com.BioTy.Planty.entity.SensorLogs;
 import com.BioTy.Planty.entity.UserPlant;
 import com.BioTy.Planty.repository.IotRepository;
+import com.BioTy.Planty.repository.SensorLogsRepository;
 import com.BioTy.Planty.repository.UserPlantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -16,9 +26,39 @@ public class IotService {
     private final IotRepository iotRepository;
     private final UserPlantRepository userPlantRepository;
     private final AdafruitClient adafruitClient;
+    private final SensorLogsRepository sensorLogsRepository;
 
     public List<IotDevice> getDevicesByUserId(Long userId){
         return iotRepository.findAllByUserId(userId);
+    }
+
+    public void fetchAndSaveSensorLog(Long deviceId) {
+        String lightKey = "planty.lightintensity";
+        String tempKey = "planty.temperature";
+        String humidKey = "planty.soilmoisture";
+
+        SensorLogResponseDto light = adafruitClient.fetchFeedInfo(lightKey);
+        SensorLogResponseDto temperature = adafruitClient.fetchFeedInfo(tempKey);
+        SensorLogResponseDto humidity = adafruitClient.fetchFeedInfo(humidKey);
+
+        IotDevice device = iotRepository.findById(deviceId)
+                .orElseThrow(() -> new RuntimeException("기기를 찾을 수 없습니다."));
+
+        BigDecimal lightVal = new BigDecimal(light.getLastValue());
+        BigDecimal temperatureVal = new BigDecimal(temperature.getLastValue());
+        BigDecimal humidityVal = new BigDecimal(humidity.getLastValue());
+
+
+        // 가장 최신 updatedAt 기준으로 기록 시간 저장
+        LocalDateTime recordedAt = Stream.of(light, temperature, humidity)
+                .map(f -> ZonedDateTime.parse(f.getUpdatedAt()))
+                .max(Comparator.naturalOrder())
+                .get()
+                .withZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                .toLocalDateTime();
+
+        SensorLogs logs = new SensorLogs(device,lightVal, temperatureVal, humidityVal, recordedAt);
+        sensorLogsRepository.save(logs);
     }
 
     public void sendAction(Long userPlantId, Long userId, String actionType) {

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -1,7 +1,7 @@
 package com.BioTy.Planty.service;
 
 import com.BioTy.Planty.entity.IotDevice;
-import com.BioTy.Planty.repository.IotDeviceRepository;
+import com.BioTy.Planty.repository.IotRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,10 +9,10 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class IotDeviceService {
-    private final IotDeviceRepository iotDeviceRepository;
+public class IotService {
+    private final IotRepository iotRepository;
 
     public List<IotDevice> getDevicesByUserId(Long userId){
-        return iotDeviceRepository.findAllByUserId(userId);
+        return iotRepository.findAllByUserId(userId);
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -1,7 +1,10 @@
 package com.BioTy.Planty.service;
 
+import com.BioTy.Planty.config.AdafruitClient;
 import com.BioTy.Planty.entity.IotDevice;
+import com.BioTy.Planty.entity.UserPlant;
 import com.BioTy.Planty.repository.IotRepository;
+import com.BioTy.Planty.repository.UserPlantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,8 +14,26 @@ import java.util.List;
 @RequiredArgsConstructor
 public class IotService {
     private final IotRepository iotRepository;
+    private final UserPlantRepository userPlantRepository;
+    private final AdafruitClient adafruitClient;
 
     public List<IotDevice> getDevicesByUserId(Long userId){
         return iotRepository.findAllByUserId(userId);
+    }
+
+    public void sendAction(Long userPlantId, Long userId, String actionType) {
+        UserPlant userPlant = userPlantRepository.findById(userPlantId)
+                .orElseThrow(() -> new RuntimeException("반려식물이 존재하지 않습니다."));
+
+        if (!userPlant.getUser().getId().equals(userId)) {
+            throw new RuntimeException("해당 식물에 대한 권한이 없습니다.");
+        }
+
+        switch (actionType.toUpperCase()) {
+            case "WATER" -> adafruitClient.sendCommand("action.water");
+            case "FAN"   -> adafruitClient.sendCommand("action.fan");
+            case "LIGHT" -> adafruitClient.sendCommand("action.light");
+            default      -> throw new IllegalArgumentException("지원하지 않는 명령입니다.");
+        }
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -27,7 +26,6 @@ public class IotService {
     private final UserPlantRepository userPlantRepository;
     private final AdafruitClient adafruitClient;
     private final SensorLogsRepository sensorLogsRepository;
-    private final PlantStatusService plantStatusService;
 
     public List<IotDevice> getDevicesByUserId(Long userId){
         return iotRepository.findAllByUserId(userId);
@@ -60,9 +58,6 @@ public class IotService {
 
         SensorLogs logs = new SensorLogs(device, temperatureVal, humidityVal, lightVal, recordedAt);
         sensorLogsRepository.save(logs);
-
-        // 식물 점수 계산 및 업데이트 (환경 기준과 비교)
-        plantStatusService.evaluatePlantStatus(deviceId);
     }
 
     public void sendAction(Long userPlantId, Long userId, String actionType) {

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -60,7 +60,7 @@ public class IotService {
         sensorLogsRepository.save(logs);
     }
 
-    public void sendAction(Long userPlantId, Long userId, String actionType) {
+    public void sendCommandToAdafruit(Long userPlantId, Long userId, String actionType) {
         UserPlant userPlant = userPlantRepository.findById(userPlantId)
                 .orElseThrow(() -> new RuntimeException("반려식물이 존재하지 않습니다."));
 

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -27,6 +27,7 @@ public class IotService {
     private final UserPlantRepository userPlantRepository;
     private final AdafruitClient adafruitClient;
     private final SensorLogsRepository sensorLogsRepository;
+    private final PlantStatusService plantStatusService;
 
     public List<IotDevice> getDevicesByUserId(Long userId){
         return iotRepository.findAllByUserId(userId);
@@ -59,6 +60,9 @@ public class IotService {
 
         SensorLogs logs = new SensorLogs(device, temperatureVal, humidityVal, lightVal, recordedAt);
         sensorLogsRepository.save(logs);
+
+        // 식물 점수 계산 및 업데이트 (환경 기준과 비교)
+        plantStatusService.evaluatePlantStatus(deviceId);
     }
 
     public void sendAction(Long userPlantId, Long userId, String actionType) {

--- a/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
+++ b/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,19 +21,38 @@ public class PlantStatusService {
     private final SensorLogsRepository sensorLogsRepository;
     private final PlantEnvStandardsRepository plantEnvStandardsRepository;
     private final PlantStatusRepository plantStatusRepository;
+    private final IotService iotService;
 
     public void evaluatePlantStatus(Long deviceId){
+        // 1. 최신 센서 로그 조회 & 반려식물과 환경기준 조회
         SensorLogs latestLog = sensorLogsRepository.findTopByIotDevice_IdOrderByRecordedAtDesc(deviceId)
                 .orElseThrow(() -> new RuntimeException("센서 로그 없음"));
         UserPlant userPlant = latestLog.getIotDevice().getUserPlant();
         PlantEnvStandards standards = plantEnvStandardsRepository.findByPlantInfo(userPlant.getPlantInfo())
                 .orElseThrow(() -> new RuntimeException("환경 기준 없음"));
 
+        // 2. 센서값과 환경 기준 비교해 점수 계산 & 상태메시지 생성
         int temperatureScore = calcScore(latestLog.getTemperature(), standards.getMinTemperature(), standards.getMaxTemperature());
         int lightScore = calcScore(latestLog.getLight(), standards.getMinLight(), standards.getMaxLight());
         int humidityScore = calcScore(latestLog.getHumidity(), standards.getMinHumidity(), standards.getMaxHumidity());
-
         String msg = createStatusMessage(temperatureScore, lightScore, humidityScore);
+
+        // 3. 명령 판단
+        List<String> actionTypes = determinAction(temperatureScore, lightScore, humidityScore);
+        boolean actionNeeded = !actionTypes.isEmpty();
+
+        // 4. 자동제어 여부 분기
+        if(actionNeeded && userPlant.isAutoControlEnabled()) {
+            for (String action : actionTypes) {
+                try {
+                    iotService.sendAction(userPlant.getId(), userPlant.getUser().getId(), action);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        // 5. 상태 저장 (actionNeeded는 자동제어 OFF이고 기준 미달일 때만 true)
         PlantStatus status = PlantStatus.builder()
                 .userPlant(userPlant)
                 .temperatureScore(temperatureScore)
@@ -39,6 +60,7 @@ public class PlantStatusService {
                 .humidityScore(humidityScore)
                 .statusMessage(msg)
                 .checkedAt(LocalDateTime.now())
+                .actionNeeded(!userPlant.isAutoControlEnabled() && actionNeeded)
                 .build();
 
         plantStatusRepository.save(status);
@@ -50,11 +72,19 @@ public class PlantStatusService {
     }
 
     // 임시 메시지 (추후 AI 연동 - 성격에 맞게 변경)
-    private String createStatusMessage(int temp, int humid, int light) {
-        if (temp + humid + light == 3) return "모든 환경이 아주 좋아요!";
-        if (humid == 0) return "습도가 너무 낮아요. 물이 필요해요!";
-        if (light == 0) return "빛이 부족해요. 햇볕이 필요해요!";
+    private String createStatusMessage(int temp, int light, int humid) {
+        if (temp + light + humid == 3) return "모든 환경이 아주 좋아요!";
         if (temp == 0) return "온도가 적절하지 않아요!";
+        if (light == 0) return "빛이 부족해요. 햇볕이 필요해요!";
+        if (humid == 0) return "습도가 너무 낮아요. 물이 필요해요!";
         return "식물의 상태를 다시 확인해주세요.";
+    }
+
+    private List<String> determinAction(int tempScore, int lightScore, int humidScore){
+        List<String> actions = new ArrayList<>();
+        if (tempScore == 0) actions.add("FAN");
+        if (lightScore == 0) actions.add("LIGHT");
+        if (humidScore == 0) actions.add("WATER");
+        return null;
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
+++ b/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
@@ -45,7 +45,7 @@ public class PlantStatusService {
 
         // 4. 자동제어 여부에 따라 분기 처리
         if (actionNeeded && userPlant.isAutoControlEnabled()) {
-            deviceCommandService.sendActions(userPlant, actionTypes);
+            deviceCommandService.executeCommands(userPlant, actionTypes);
         }
 
         // 5. 상태 저장 (actionNeeded는 자동제어 OFF이고 기준 미달일 때만 true)

--- a/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
+++ b/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
@@ -9,6 +9,7 @@ import com.BioTy.Planty.repository.PlantStatusRepository;
 import com.BioTy.Planty.repository.SensorLogsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ public class PlantStatusService {
     private final PlantStatusRepository plantStatusRepository;
     private final DeviceCommandService deviceCommandService;
 
+    @Transactional
     public void evaluatePlantStatus(Long deviceId){
         // 1. 최신 센서 로그 조회 & 반려식물과 환경기준 조회
         SensorLogs latestLog = sensorLogsRepository.findTopByIotDevice_IdOrderByRecordedAtDesc(deviceId)

--- a/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
+++ b/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
@@ -1,0 +1,60 @@
+package com.BioTy.Planty.service;
+
+import com.BioTy.Planty.entity.PlantEnvStandards;
+import com.BioTy.Planty.entity.PlantStatus;
+import com.BioTy.Planty.entity.SensorLogs;
+import com.BioTy.Planty.entity.UserPlant;
+import com.BioTy.Planty.repository.PlantEnvStandardsRepository;
+import com.BioTy.Planty.repository.PlantStatusRepository;
+import com.BioTy.Planty.repository.SensorLogsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PlantStatusService {
+    private final SensorLogsRepository sensorLogsRepository;
+    private final PlantEnvStandardsRepository plantEnvStandardsRepository;
+    private final PlantStatusRepository plantStatusRepository;
+
+    public void evaluatePlantStatus(Long deviceId){
+        SensorLogs latestLog = sensorLogsRepository.findTopByIotDevice_IdOrderByRecordedAtDesc(deviceId)
+                .orElseThrow(() -> new RuntimeException("센서 로그 없음"));
+        UserPlant userPlant = latestLog.getIotDevice().getUserPlant();
+        PlantEnvStandards standards = plantEnvStandardsRepository.findByPlantInfo(userPlant.getPlantInfo())
+                .orElseThrow(() -> new RuntimeException("환경 기준 없음"));
+
+        int temperatureScore = calcScore(latestLog.getTemperature(), standards.getMinTemperature(), standards.getMaxTemperature());
+        int lightScore = calcScore(latestLog.getLight(), standards.getMinLight(), standards.getMaxLight());
+        int humidityScore = calcScore(latestLog.getHumidity(), standards.getMinHumidity(), standards.getMaxHumidity());
+
+        String msg = createStatusMessage(temperatureScore, lightScore, humidityScore);
+        PlantStatus status = PlantStatus.builder()
+                .userPlant(userPlant)
+                .temperatureScore(temperatureScore)
+                .lightScore(lightScore)
+                .humidityScore(humidityScore)
+                .statusMessage(msg)
+                .checkedAt(LocalDateTime.now())
+                .build();
+
+        plantStatusRepository.save(status);
+    }
+
+    private int calcScore(BigDecimal value, int min, int max){
+        return (value.compareTo(BigDecimal.valueOf(min)) >= 0 &&
+                value.compareTo(BigDecimal.valueOf(max)) <= 0) ? 1 : 0;
+    }
+
+    // 임시 메시지 (추후 AI 연동 - 성격에 맞게 변경)
+    private String createStatusMessage(int temp, int humid, int light) {
+        if (temp + humid + light == 3) return "모든 환경이 아주 좋아요!";
+        if (humid == 0) return "습도가 너무 낮아요. 물이 필요해요!";
+        if (light == 0) return "빛이 부족해요. 햇볕이 필요해요!";
+        if (temp == 0) return "온도가 적절하지 않아요!";
+        return "식물의 상태를 다시 확인해주세요.";
+    }
+}

--- a/src/main/java/com/BioTy/Planty/service/UserPlantService.java
+++ b/src/main/java/com/BioTy/Planty/service/UserPlantService.java
@@ -19,7 +19,7 @@ public class UserPlantService {
     private final UserRepository userRepository;
     private final PlantInfoRepository plantInfoRepository;
     private final PersonalityRepository personalityRepository;
-    private final IotDeviceRepository iotDeviceRepository;
+    private final IotRepository iotRepository;
 
     // 사용자 반려식물 목록 조회
     public List<UserPlantSummaryResponseDto> getUserPlants(Long userId){
@@ -68,7 +68,7 @@ public class UserPlantService {
     public void registerDevice(Long userPlantId, Long iotDeviceId){
         UserPlant userPlant = userPlantRepository.findById(userPlantId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 반려식물이 존재하지 않습니다."));
-        IotDevice iotDevice = iotDeviceRepository.findById(iotDeviceId)
+        IotDevice iotDevice = iotRepository.findById(iotDeviceId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 IoT 기기가 존재하지 않습니다."));
 
         userPlant.setIotDevice(iotDevice);


### PR DESCRIPTION
### Pull Request
iot 센서 기반 자동 제어 로직 구현

**🪾작업한 브랜치**
- feat/# 7-iot

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-BE/issues/7

**🔥 작업 내용**
- sensor_logs 테이블에 센서 데이터 저장 (Adafruit 연동)
- plant_env_standards 기준과 비교해 상태 평가 후 plant_status에 저장
- 자동제어 모드 ON 시, Adafruit API로 물주기/팬/전등 명령 자동 전송
- 자동제어 모드 OFF 시, action_needed = true 상태 저장
- 수동 명령 전송 API (POST /iot/{userPlantId}/actions) 구현
- 명령 전송 시 device_commands, device_action_logs에 기록

**🌿 흐름**
1. 매시 정각마다 Adafruit에서 센서 데이터를 수신하여 sensor_logs 테이블에 저장
<img width="508" alt="image" src="https://github.com/user-attachments/assets/ba11afdd-7c3e-4549-b3dd-4ac2bc64424f" />

*현재 Adafruit에서 마지막으로 센서값이 업데이트된 시간: 2025-03-24 16:24:07.000000

2. 저장된 센서값을 plant_env_standards 기준과 비교해 점수를 산정 (임시: 0 또는 1)
- sensor_logs.device_id → user_plant 조회
- user_plant.plant_info_id → plant_env_standards 조회
- 온도 / 습도 / 광량을 기준값과 비교하여 점수 계산 (기준 벗어나면 0, 충족하면 1)

3. 기준 미달 항목에 따라 필요한 명령(WATER, FAN, LIGHT)을 판단
- 필요한 명령이 있을 경우 actionNeeded = true로 상태 표시

4. 자동제어 여부에 따라 분기 처리
- 자동제어 ON → 명령 즉시 전송 (executeCommand 호출), actionNeeded = false 처리
- 자동제어 OFF → 명령은 전송하지 않고 상태만 저장 (추후 사용자가 프론트에서 버튼 누르면 POST /iot/{userPlantId}/actions 수행되도록 함)

5. 명령 수행 시 (executeCommand)
- Adafruit API를 통해 물주기 / 팬 / 전등 명령 전송
- 전송한 명령을 device_commands 테이블에 기록
- 명령 실행 결과를 device_action_logs에 기록 (status: pending, 추후 success/fail 업데이트 예정)

7. 최종 상태 저장
- 상태 메시지 및 점수를 포함한 결과를 plant_status 테이블에 저장


**🚀 추후 고려사항 (성능 개선 & 확장성)**
1. 명령 실행 완료 로직 구현
→ 일정 시간 후 device_action_logs.executed_at, result 업데이트 필요

8. Firebase 푸시 알림 연동
→ DB 기반으로 알림 전송 처리 예정

9. 점수 산정 방식 개선 (0~3 하트)
→ 기준값 범위 외 편차에 따라 점수 차등 부여

10. Kafka 도입 (센서 수신 → 상태 평가 / 명령 전송 분리)
→ 비동기 처리, 확장성 및 알림 연계 고려
