### PR TITLE
[Feat] #18 - 반려식물 관련 기능 개선

### DIFF
--- a/src/main/java/com/BioTy/Planty/controller/IotController.java
+++ b/src/main/java/com/BioTy/Planty/controller/IotController.java
@@ -36,13 +36,8 @@ public class IotController {
     ) {
         token = token.replace("Bearer ", "");
         Long userId = authService.getUserIdFromToken(token);
-        List<IotDevice> devices = iotService.getDevicesByUserId(userId);
 
-        List<IotDeviceResponseDto> response = devices.stream()
-                .map(IotDeviceResponseDto::from)
-                .collect(Collectors.toList());
-
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(iotService.getDevicesByUserId(userId));
     }
 
     @Operation(

--- a/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
+++ b/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
@@ -81,4 +81,20 @@ public class UserPlantController {
     public UserPlantDetailResponseDto getUserPlantDetail(@PathVariable Long userPlantId) {
         return userPlantService.getUserPlantDetail(userPlantId);
     }
+
+    // 반려식물 삭제
+    @Operation(
+            summary = "반려식물 삭제",
+            description = "userPlantId를 이용해 반려식물을 삭제합니다. (연결된 IoT 디바이스도 자동으로 해제)")
+    @DeleteMapping("/{userPlantId}")
+    public ResponseEntity<Void> deleteUserPlant(
+            @PathVariable Long userPlantId,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token
+    ){
+        token = token.replace("Bearer ", "");
+        Long userId = authService.getUserIdFromToken(token);
+
+        userPlantService.deleteUserPlant(userPlantId, userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
+++ b/src/main/java/com/BioTy/Planty/controller/UserPlantController.java
@@ -4,6 +4,7 @@ import com.BioTy.Planty.dto.iot.RegisterDeviceRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantCreateRequestDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantDetailResponseDto;
 import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
+import com.BioTy.Planty.dto.userPlant.UserPlantEditDto;
 import com.BioTy.Planty.service.AuthService;
 import com.BioTy.Planty.service.UserPlantService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -96,5 +97,37 @@ public class UserPlantController {
 
         userPlantService.deleteUserPlant(userPlantId, userId);
         return ResponseEntity.noContent().build();
+    }
+
+    // 반려식물 수정용 조회
+    @Operation(
+            summary = "수정용 반려식물 정보 조회",
+            description = "수정을 위한 반려식물의 정보를 조회합니다.")
+    @GetMapping("/edit/{userPlantId}")
+    public UserPlantEditDto getUserPlantForEdit(
+            @PathVariable Long userPlantId,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token
+    ) {
+        token = token.replace("Bearer ", "");
+        Long userId = authService.getUserIdFromToken(token);
+
+        return userPlantService.getUserPlantForEdit(userPlantId, userId);
+    }
+
+    // 반려식물 수정
+    @Operation(
+            summary = "반려식물 정보 수정",
+            description = "반려식물의 정보를 수정합니다.")
+    @PutMapping("/edit/{userPlantId}")
+    public ResponseEntity<Void> editUserPlant(
+            @PathVariable Long userPlantId,
+            @RequestBody UserPlantEditDto requestDto,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String token
+    ){
+        token = token.replace("Bearer ", "");
+        Long userId = authService.getUserIdFromToken(token);
+
+        userPlantService.editUserPlant(userPlantId, userId, requestDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/BioTy/Planty/dto/iot/IotDeviceResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/iot/IotDeviceResponseDto.java
@@ -11,6 +11,7 @@ public class IotDeviceResponseDto {
     private String deviceSerial;
     private String model;
     private String status;
+    private boolean isConnected;
 
     public static IotDeviceResponseDto from(IotDevice device){
         return IotDeviceResponseDto.builder()
@@ -18,6 +19,7 @@ public class IotDeviceResponseDto {
                 .deviceSerial(device.getDeviceSerial())
                 .model(device.getModel())
                 .status(device.getStatus())
+                .isConnected(device.getUserPlant() != null)
                 .build();
     }
 }

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantDetailResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantDetailResponseDto.java
@@ -4,6 +4,7 @@ import com.BioTy.Planty.dto.plant.PlantInfoDetailResponseDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailEnvStandardDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailSensorDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailStatusDto;
+import com.BioTy.Planty.entity.IotDevice;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -20,10 +21,12 @@ public class UserPlantDetailResponseDto {
     private DetailEnvStandardDto envStandard; // 환경 기준 (min, max값)
     private DetailSensorDto sensorData; // 최신 센서 데이터
     private DetailStatusDto status; // 최신 상태 (0~3점, 상태 메시지)
+    private IotDevice iotDevice;
 
     public UserPlantDetailResponseDto(long id, String nickname, String imageUrl, LocalDate adoptedAt,
                                       PersonalityResponseDto personality, PlantInfoDetailResponseDto plantInfo,
-                                      DetailEnvStandardDto envStandard, DetailStatusDto status, DetailSensorDto sensorData) {
+                                      DetailEnvStandardDto envStandard, DetailStatusDto status,
+                                      DetailSensorDto sensorData, IotDevice iotDevice) {
         this.id = id;
         this.nickname = nickname;
         this.imageUrl = imageUrl;
@@ -33,6 +36,7 @@ public class UserPlantDetailResponseDto {
         this.envStandard = envStandard;
         this.status = status;
         this.sensorData = sensorData;
+        this.iotDevice = iotDevice;
     }
 
 }

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantEditDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantEditDto.java
@@ -1,0 +1,20 @@
+package com.BioTy.Planty.dto.userPlant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserPlantEditDto {
+    private String nickname;
+    private LocalDate adoptedAt;
+    private Boolean autoControlEnabled;
+    private Long personalityId;
+    private Long deviceId;
+}

--- a/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantEditDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/userPlant/UserPlantEditDto.java
@@ -16,5 +16,4 @@ public class UserPlantEditDto {
     private LocalDate adoptedAt;
     private Boolean autoControlEnabled;
     private Long personalityId;
-    private Long deviceId;
 }

--- a/src/main/java/com/BioTy/Planty/entity/IotDevice.java
+++ b/src/main/java/com/BioTy/Planty/entity/IotDevice.java
@@ -6,13 +6,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "iot_device")
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor()
 public class IotDevice {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,6 +26,4 @@ public class IotDevice {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
-
-    private LocalDateTime lastOnline;
 }

--- a/src/main/java/com/BioTy/Planty/entity/IotDevice.java
+++ b/src/main/java/com/BioTy/Planty/entity/IotDevice.java
@@ -4,12 +4,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "iot_device")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IotDevice {
     @Id

--- a/src/main/java/com/BioTy/Planty/entity/UserPlant.java
+++ b/src/main/java/com/BioTy/Planty/entity/UserPlant.java
@@ -1,10 +1,7 @@
 package com.BioTy.Planty.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -13,6 +10,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserPlant {
     @Id

--- a/src/main/java/com/BioTy/Planty/entity/UserPlant.java
+++ b/src/main/java/com/BioTy/Planty/entity/UserPlant.java
@@ -41,6 +41,9 @@ public class UserPlant {
     @OneToMany(mappedBy = "userPlant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlantStatus> statuses = new ArrayList<>();
 
+    @OneToMany(mappedBy = "userPlant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatRoom> chatRooms = new ArrayList<>();
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "iot_device_id")
     private IotDevice iotDevice;

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
@@ -116,9 +116,13 @@ public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
                 LIMIT 1
             ) ps ON ps.user_plant_id = up.id
             LEFT JOIN (
-                SELECT sl1.*
+              SELECT *
+              FROM (
+                SELECT sl1.*,\s
+                       ROW_NUMBER() OVER (PARTITION BY sl1.device_id ORDER BY sl1.recorded_at DESC) AS rn
                 FROM sensor_logs sl1
-                ORDER BY sl1.recorded_at DESC
+              ) filtered
+              WHERE rn = 1
             ) sl ON sl.device_id = id.id
             WHERE up.id = ?1
         """;

--- a/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserPlantRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.BioTy.Planty.dto.userPlant.UserPlantSummaryResponseDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailEnvStandardDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailSensorDto;
 import com.BioTy.Planty.dto.userPlant.detail.DetailStatusDto;
+import com.BioTy.Planty.entity.IotDevice;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
@@ -101,7 +102,10 @@ public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
               ps.temperature_score, ps.light_score, ps.humidity_score, ps.status_message, ps.checked_at,
 
               -- SensorLogs (latest)
-              sl.temperature, sl.humidity, sl.light, sl.recorded_at
+              sl.temperature, sl.humidity, sl.light, sl.recorded_at,
+              
+              -- IotDevice
+              id.id, id.device_serial, id.model, id.status
 
             FROM user_plant up
             LEFT JOIN personality p ON up.personality_id = p.id
@@ -239,6 +243,20 @@ public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
         )
                 : null;
 
+        Long deviceId = result[idx] != null ? ((Number) result[idx++]).longValue() : null;
+        String deviceSerial = (String) result[idx++];
+        String deviceModel = (String) result[idx++];
+        String deviceStatus = (String) result[idx++];
+
+        IotDevice iotDevice = null;
+        if (deviceId != null) {
+            iotDevice = new IotDevice();
+            iotDevice.setId(deviceId);
+            iotDevice.setDeviceSerial(deviceSerial);
+            iotDevice.setModel(deviceModel);
+            iotDevice.setStatus(deviceStatus);
+        }
+
         // --- 최종 조립
         return new UserPlantDetailResponseDto(
                 userPlantIdRes,
@@ -249,7 +267,8 @@ public class UserPlantRepositoryImpl implements UserPlantRepositoryCustom {
                 plantInfo,
                 envStandard,
                 statusDto,
-                sensorDto
+                sensorDto,
+                iotDevice
         );
 
     }

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -1,6 +1,7 @@
 package com.BioTy.Planty.service;
 
 import com.BioTy.Planty.config.AdafruitClient;
+import com.BioTy.Planty.dto.iot.IotDeviceResponseDto;
 import com.BioTy.Planty.dto.iot.SensorLogResponseDto;
 import com.BioTy.Planty.entity.IotDevice;
 import com.BioTy.Planty.entity.SensorLogs;
@@ -27,8 +28,10 @@ public class IotService {
     private final AdafruitClient adafruitClient;
     private final SensorLogsRepository sensorLogsRepository;
 
-    public List<IotDevice> getDevicesByUserId(Long userId){
-        return iotRepository.findAllByUserId(userId);
+    public List<IotDeviceResponseDto> getDevicesByUserId(Long userId){
+        return iotRepository.findAllByUserId(userId).stream()
+                .map(IotDeviceResponseDto::from)
+                .toList();
     }
 
     public void fetchAndSaveSensorLog(Long deviceId) {

--- a/src/main/java/com/BioTy/Planty/service/UserPlantService.java
+++ b/src/main/java/com/BioTy/Planty/service/UserPlantService.java
@@ -111,8 +111,7 @@ public class UserPlantService {
                 userPlant.getNickname(),
                 userPlant.getAdoptedAt(),
                 userPlant.isAutoControlEnabled(),
-                userPlant.getPersonality().getId(),
-                userPlant.getIotDevice() != null ? userPlant.getIotDevice().getId() : null
+                userPlant.getPersonality().getId()
         );
     }
 
@@ -137,23 +136,6 @@ public class UserPlantService {
                     .orElseThrow(() -> new IllegalArgumentException("해당 ID의 성격이 존재하지 않습니다."));
             userPlant.setPersonality(newPersonality);
         }
-
-        IotDevice newDevice = null;
-        if (dto.getDeviceId() != null) {
-            newDevice = iotRepository.findById(dto.getDeviceId())
-                    .orElseThrow(() -> new IllegalArgumentException("IoT 디바이스를 찾을 수 없습니다."));
-        }
-
-        IotDevice currentDevice = userPlant.getIotDevice();
-        if (currentDevice != null && !currentDevice.equals(newDevice)) {
-            currentDevice.setUserPlant(null);
-        }
-
-        if (newDevice != null) {
-            newDevice.setUserPlant(userPlant);
-        }
-
-        userPlant.setIotDevice(newDevice);
     }
 
 }


### PR DESCRIPTION
### Pull Request
반려식물 수정/삭제 기능 추가 및 IoT 관련 기능 개선

**🪾작업한 브랜치**
- hotfix/overall

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-BE/issues/18
- https://github.com/Team-BIoTy/Planty-FE/issues/18

**🔥 작업 내용**
- 반려식물 삭제 API 구현
   - DELETE /user-plants/{id}
   - IoT 연결도 함께 해제됨 (UserPlant.iotDevice = null)
   - 관련 PlantStatus, ChatRoom은 cascade로 자동 삭제됨
- 반려식물 수정용 조회 API 구현
   - GET /user-plants/edit/{userPlantId}
   - 클라이언트에서 수정 시 필요한 정보만 선별적으로 응답
- 반려식물 수정 API 구현
   - PUT /user-plants/edit/{userPlantId}
   - 애칭, 입양일, 성격, 자동제어모드 수정 가능
- IoT 디바이스 연결 여부 추가
   - IotDeviceResponseDto에 connected 필드 추가 (userPlant != null 여부 기반)
- 반려식물 상세 응답 확장
   - GET /user-plants/{userPlantId} 응답에 IoT 디바이스 정보 포함