### PR TITLE
[Feat] #22 - Agent 챗봇 연동, 최신 센서 데이터 요청 추가

### DIFF
--- a/src/main/java/com/BioTy/Planty/config/AdafruitClient.java
+++ b/src/main/java/com/BioTy/Planty/config/AdafruitClient.java
@@ -38,14 +38,14 @@ public class AdafruitClient {
         return restTemplate.exchange(url, HttpMethod.GET, request, SensorLogResponseDto.class).getBody();
     }
 
-    public void sendCommand(String feedKey){
+    public void sendCommand(String feedKey, String value){
         String url = String.format("%s/api/v2/%s/feeds/%s/data", baseUrl, username, feedKey);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("X-AIO-Key", apiKey);
 
-        Map<String, String> body = Map.of("value", "ON");
+        Map<String, String> body = Map.of("value", value);
 
         HttpEntity<Map<String, String>> request = new HttpEntity<>(body, headers);
         restTemplate.postForEntity(url, request, String.class);

--- a/src/main/java/com/BioTy/Planty/controller/ChatController.java
+++ b/src/main/java/com/BioTy/Planty/controller/ChatController.java
@@ -79,7 +79,13 @@ public class ChatController {
             @PathVariable Long chatRoomId,
             @RequestBody SendMessageRequestDto request
             ){
-        ChatMessageResponseDto response = chatService.sendMessage(chatRoomId, request.getMessage());
+        ChatMessageResponseDto response = chatService.sendMessage(
+                chatRoomId,
+                request.getMessage(),
+                request.getSensorLogId(),
+                request.getPlantEnvStandardsId(),
+                request.getPersona()
+        );
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/BioTy/Planty/dto/chat/ChatRoomDetailDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/chat/ChatRoomDetailDto.java
@@ -11,6 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 public class ChatRoomDetailDto {
     private Long chatRoomId;
+    private Long userPlantId;
     private String userPlantNickname;
     private String imageUrl;
     private String personalityLabel;

--- a/src/main/java/com/BioTy/Planty/dto/chat/ChatRoomDetailDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/chat/ChatRoomDetailDto.java
@@ -16,5 +16,7 @@ public class ChatRoomDetailDto {
     private String personalityLabel;
     private String personalityEmoji;
     private String personalityColor;
+    private Long sensorLogId;
+    private Long plantEnvStandardsId;
     private List<ChatMessageResponseDto> messages;
 }

--- a/src/main/java/com/BioTy/Planty/dto/chat/SendMessageRequestDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/chat/SendMessageRequestDto.java
@@ -9,4 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SendMessageRequestDto {
     private String message;
+    private Long sensorLogId;
+    private Long plantEnvStandardsId;
+    private String persona;
 }

--- a/src/main/java/com/BioTy/Planty/entity/ChatMessage.java
+++ b/src/main/java/com/BioTy/Planty/entity/ChatMessage.java
@@ -22,7 +22,9 @@ public class ChatMessage {
     @Enumerated(EnumType.STRING)
     private Sender sender; // USER or BOT
 
+    @Column(columnDefinition = "TEXT")
     private String message;
+
     private LocalDateTime timestamp = LocalDateTime.now();
 
     public ChatMessage(Long chatRoomId, Sender sender, String message) {

--- a/src/main/java/com/BioTy/Planty/entity/SensorLogs.java
+++ b/src/main/java/com/BioTy/Planty/entity/SensorLogs.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -25,12 +26,14 @@ public class SensorLogs {
     private BigDecimal light;
 
     private LocalDateTime recordedAt;
+    private LocalDateTime checkedAt;
 
-    public SensorLogs(IotDevice iotDevice, BigDecimal temperature, BigDecimal humidity, BigDecimal light, LocalDateTime recordedAt) {
+    public SensorLogs(IotDevice iotDevice, BigDecimal temperature, BigDecimal humidity, BigDecimal light, LocalDateTime recordedAt, LocalDateTime checkedAt) {
         this.iotDevice = iotDevice;
         this.temperature = temperature;
         this.humidity = humidity;
         this.light = light;
         this.recordedAt = recordedAt;
+        this.checkedAt = checkedAt;
     }
 }

--- a/src/main/java/com/BioTy/Planty/service/ChatService.java
+++ b/src/main/java/com/BioTy/Planty/service/ChatService.java
@@ -4,17 +4,22 @@ import com.BioTy.Planty.dto.chat.ChatIdResponseDto;
 import com.BioTy.Planty.dto.chat.ChatMessageResponseDto;
 import com.BioTy.Planty.dto.chat.ChatRoomDetailDto;
 import com.BioTy.Planty.dto.chat.ChatRoomSummaryDto;
-import com.BioTy.Planty.entity.ChatMessage;
-import com.BioTy.Planty.entity.ChatRoom;
-import com.BioTy.Planty.entity.UserPlant;
+import com.BioTy.Planty.entity.*;
 import com.BioTy.Planty.repository.ChatMessageRepository;
 import com.BioTy.Planty.repository.ChatRoomRepository;
+import com.BioTy.Planty.repository.PlantEnvStandardsRepository;
+import com.BioTy.Planty.repository.SensorLogsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.*;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,6 +28,10 @@ import java.util.stream.Collectors;
 public class ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final SensorLogsRepository sensorLogsRepository;
+    private final PlantEnvStandardsRepository plantEnvStandardsRepository;
+
+    private final RestTemplate restTemplate = new RestTemplate();
 
     // 1. 채팅 시작
     public ChatIdResponseDto startChat(Long userId, Long userPlantId){
@@ -75,6 +84,25 @@ public class ChatService {
         String personalityEmoji = userPlant != null ? userPlant.getPersonality().getEmoji() : null;
         String personalityColor = userPlant != null ? userPlant.getPersonality().getColor() : null;
 
+        // Iot 디바이스가 null일 수 있음
+        Long sensorLogId = null;
+        if (userPlant != null && userPlant.getIotDevice() != null) {
+            SensorLogs latestLog = sensorLogsRepository
+                    .findTopByIotDevice_IdOrderByRecordedAtDesc(userPlant.getIotDevice().getId())
+                    .orElse(null);
+            if (latestLog != null) {
+                sensorLogId = latestLog.getId();
+            }
+        }
+        // 환경기준값이 null일 수 있음
+        Long plantEnvStandardsId = null;
+        if (userPlant != null && userPlant.getPlantInfo() != null) {
+            plantEnvStandardsId = plantEnvStandardsRepository
+                    .findByPlantInfo(userPlant.getPlantInfo())
+                    .map(PlantEnvStandards::getId)
+                    .orElse(null);
+        }
+
         List<ChatMessageResponseDto> messages = chatMessageRepository.findByChatRoomIdOrderByTimestampAsc(chatRoomId).stream()
                 .map(msg -> new ChatMessageResponseDto(
                         msg.getSender().name(),
@@ -90,29 +118,55 @@ public class ChatService {
                 personalityLabel,
                 personalityEmoji,
                 personalityColor,
+                sensorLogId,
+                plantEnvStandardsId,
                 messages
         );
     }
 
 
     // 4. 메시지 전송
-    public ChatMessageResponseDto sendMessage(Long chatRoomId, String message) {
+    public ChatMessageResponseDto sendMessage(Long chatRoomId, String message,
+                                              Long sensorLogId, Long plantEnvStandardsId, String persona) {
         // 1) 사용자 메시지 저장
         ChatMessage userMsg = chatMessageRepository.save(
                 new ChatMessage(chatRoomId, ChatMessage.Sender.USER, message)
         );
 
-        // 2) AI 서버와 통신해서 챗봇 응답 받기 & 저장 (TODO)
-        String botReply = "테스트 응답입니다"; // 임시
+        // 2) Agent 서버 호출
+        String botReply = "기본 응답입니다 (Agent 연결 실패)";
+        try {
+            String aiServerUrl = "http://localhost:8000/chat";
+
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("chat_room_id", chatRoomId);
+            requestBody.put("sensor_log_id", sensorLogId);
+            requestBody.put("plant_env_standards_id", plantEnvStandardsId);
+            requestBody.put("persona", persona);
+            requestBody.put("user_input", message);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
+
+            ResponseEntity<Map> response = restTemplate.postForEntity(aiServerUrl, request, Map.class);
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                botReply = (String) response.getBody().get("final_response");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // 3) 챗봇 메시지 저장
         ChatMessage botMsg = chatMessageRepository.save(
                 new ChatMessage(chatRoomId, ChatMessage.Sender.BOT, botReply)
         );
 
-        // 3) 채팅방의 lastSenetAt 갱신
-        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
-        chatRoom.updateLastSentAt(LocalDateTime.now());
-        chatRoomRepository.save(chatRoom);
+        // 4) 채팅방의 lastSenetAt 갱신
+        chatRoomRepository.findById(chatRoomId).ifPresent(room -> {
+            room.updateLastSentAt(LocalDateTime.now());
+            chatRoomRepository.save(room);
+        });
 
         return new ChatMessageResponseDto(
                 botMsg.getSender().name(),

--- a/src/main/java/com/BioTy/Planty/service/ChatService.java
+++ b/src/main/java/com/BioTy/Planty/service/ChatService.java
@@ -113,6 +113,7 @@ public class ChatService {
 
         return new ChatRoomDetailDto(
                 chatRoomId,
+                userPlant.getId(),
                 nickname,
                 imageUrl,
                 personalityLabel,
@@ -144,6 +145,8 @@ public class ChatService {
             requestBody.put("plant_env_standards_id", plantEnvStandardsId);
             requestBody.put("persona", persona);
             requestBody.put("user_input", message);
+
+            System.out.println("🔍 [Agent 요청] " + requestBody);
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
@@ -59,7 +60,8 @@ public class IotService {
                 .withZoneSameInstant(ZoneId.of("Asia/Seoul"))
                 .toLocalDateTime();
 
-        SensorLogs logs = new SensorLogs(device, temperatureVal, humidityVal, lightVal, recordedAt);
+        SensorLogs logs = new SensorLogs(device, temperatureVal, humidityVal, lightVal,
+                recordedAt, LocalDateTime.now());
         sensorLogsRepository.save(logs);
     }
 
@@ -71,6 +73,10 @@ public class IotService {
             throw new RuntimeException("해당 식물에 대한 권한이 없습니다.");
         }
 
+        Long deviceId = userPlant.getIotDevice().getId();
+        String timestamp = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+
         switch (actionType.toUpperCase()) {
             case "WATER_ON" -> adafruitClient.sendCommand("action.water", "ON");
             case "WATER_OFF" -> adafruitClient.sendCommand("action.water", "OFF");
@@ -81,6 +87,16 @@ public class IotService {
             case "LIGHT_ON" -> adafruitClient.sendCommand("action.light", "ON");
             case "LIGHT_OFF" -> adafruitClient.sendCommand("action.light", "OFF");
 
+            case "REFRESH" -> {
+                String value = deviceId + "_" + timestamp;
+                adafruitClient.sendCommand("action.refresh", value);
+                try {
+                    Thread.sleep(3000); // 3초 정도 대기
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                fetchAndSaveSensorLog(deviceId);
+            }
             default -> throw new IllegalArgumentException("지원하지 않는 명령입니다.");
         }
     }

--- a/src/main/java/com/BioTy/Planty/service/IotService.java
+++ b/src/main/java/com/BioTy/Planty/service/IotService.java
@@ -72,10 +72,16 @@ public class IotService {
         }
 
         switch (actionType.toUpperCase()) {
-            case "WATER" -> adafruitClient.sendCommand("action.water");
-            case "FAN"   -> adafruitClient.sendCommand("action.fan");
-            case "LIGHT" -> adafruitClient.sendCommand("action.light");
-            default      -> throw new IllegalArgumentException("지원하지 않는 명령입니다.");
+            case "WATER_ON" -> adafruitClient.sendCommand("action.water", "ON");
+            case "WATER_OFF" -> adafruitClient.sendCommand("action.water", "OFF");
+
+            case "FAN_ON" -> adafruitClient.sendCommand("action.fan", "ON");
+            case "FAN_OFF" -> adafruitClient.sendCommand("action.fan", "OFF");
+
+            case "LIGHT_ON" -> adafruitClient.sendCommand("action.light", "ON");
+            case "LIGHT_OFF" -> adafruitClient.sendCommand("action.light", "OFF");
+
+            default -> throw new IllegalArgumentException("지원하지 않는 명령입니다.");
         }
     }
 }


### PR DESCRIPTION
### Pull Request
FastAPI 기반 Agent 챗봇 연동 및 센서 데이터 갱신 흐름 구현

**🪾작업한 브랜치**
- feat/# 22-chatbot-agent

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-BE/issues/22
- https://github.com/Team-BIoTy/Planty-FE/issues/22

**🔥 작업 내용**
- FastAPI 기반 Agent 서버 연동 (POST /chat)
   - 메시지 전송 시 sensorLogId, plantEnvStandardsId, persona 포함
   - 응답 파싱 및 ChatMessage 저장
   - ChatRoom.lastSentAt 갱신 처리
   - 요청 바디 로그 출력 및 예외 발생 시 기본 응답 처리
- 센서 데이터 갱신 흐름 구현
   - ChatRoomDetailDto에 userPlantId 필드 추가
   - Adafruit 명령 구조 확장: *_ON, *_OFF, REFRESH 명령 지원
   - REFRESH: deviceId_timestamp 값 전송 → 3초 대기 → 센서값 재조회 및 저장


