### PR TITLE
[Feat] #25 - 자동제어 및 상태 알림 기능 구현 (FCM)

### DIFF
--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
                                 "/chats/**",
                                 "/fcm/**",
                                 "/test/**",
+                                "/notifications/**",
 
                                 // Swagger 경로들
                                 "/swagger-ui/**",

--- a/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
+++ b/src/main/java/com/BioTy/Planty/config/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
                                 "/iot/**",
                                 "/chats/**",
                                 "/fcm/**",
+                                "/test/**",
 
                                 // Swagger 경로들
                                 "/swagger-ui/**",

--- a/src/main/java/com/BioTy/Planty/config/SensorFetchScheduler.java
+++ b/src/main/java/com/BioTy/Planty/config/SensorFetchScheduler.java
@@ -1,7 +1,7 @@
 package com.BioTy.Planty.config;
 
+import com.BioTy.Planty.entity.User;
 import com.BioTy.Planty.entity.UserPlant;
-import com.BioTy.Planty.repository.SensorLogsRepository;
 import com.BioTy.Planty.repository.UserDeviceTokenRepository;
 import com.BioTy.Planty.repository.UserPlantRepository;
 import com.BioTy.Planty.service.DeviceCommandService;
@@ -33,6 +33,7 @@ public class SensorFetchScheduler {
         for (UserPlant plant : allPlants) {
             if (plant.getIotDevice() == null) continue;
             Long deviceId = plant.getIotDevice().getId();
+            User user = plant.getUser();
 
             // 1. 센서 데이터 패치
             iotService.fetchAndSaveSensorLog(deviceId);
@@ -46,6 +47,8 @@ public class SensorFetchScheduler {
                 userDeviceTokenRepository.findByUser(plant.getUser()).ifPresent(token -> {
                     log.info("🔥 FCM 발송 → {}", statusMsg);
                     fcmService.sendMessage(
+                            user,
+                            plant,
                             token.getToken(),
                             "🌱식물 상태 알림",
                             statusMsg
@@ -59,6 +62,8 @@ public class SensorFetchScheduler {
                 deviceCommandService.executeCommands(plant, actions);
                 userDeviceTokenRepository.findByUser(plant.getUser()).ifPresent(token -> {
                     fcmService.sendMessage(
+                            user,
+                            plant,
                             token.getToken(),
                             "🌱자동제어가 작동했어요!",
                             statusMsg

--- a/src/main/java/com/BioTy/Planty/config/SensorFetchScheduler.java
+++ b/src/main/java/com/BioTy/Planty/config/SensorFetchScheduler.java
@@ -2,11 +2,14 @@ package com.BioTy.Planty.config;
 
 import com.BioTy.Planty.entity.UserPlant;
 import com.BioTy.Planty.repository.SensorLogsRepository;
+import com.BioTy.Planty.repository.UserDeviceTokenRepository;
 import com.BioTy.Planty.repository.UserPlantRepository;
 import com.BioTy.Planty.service.DeviceCommandService;
+import com.BioTy.Planty.service.FCMService;
 import com.BioTy.Planty.service.IotService;
 import com.BioTy.Planty.service.PlantStatusService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,17 +17,21 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SensorFetchScheduler {
     private final IotService iotService;
+    private final FCMService fcmService;
     private final PlantStatusService plantStatusService;
     private final DeviceCommandService deviceCommandService;
     private final UserPlantRepository userPlantRepository;
+    private final UserDeviceTokenRepository userDeviceTokenRepository;
 
     @Scheduled(cron = "0 0 * * * *") // 매시 정각마다
     public void fetchSensorDataEveryHour() {
         List<UserPlant> allPlants = userPlantRepository.findAll();
 
         for (UserPlant plant : allPlants) {
+            if (plant.getIotDevice() == null) continue;
             Long deviceId = plant.getIotDevice().getId();
 
             // 1. 센서 데이터 패치
@@ -32,10 +39,31 @@ public class SensorFetchScheduler {
 
             // 2. 상태 평가 (자동제어 설정 + 쿨타임 확인)
             List<String> actions = plantStatusService.evaluatePlantStatus(deviceId);
+            String statusMsg = plantStatusService.getLastStatusMessage(plant.getId());
 
-            // 3. 자동제어 조건이면 실행
+            // 3. 수동제어 - 상태 메시지 푸시 전송
+            if (actions.isEmpty()) {
+                userDeviceTokenRepository.findByUser(plant.getUser()).ifPresent(token -> {
+                    log.info("🔥 FCM 발송 → {}", statusMsg);
+                    fcmService.sendMessage(
+                            token.getToken(),
+                            "🌱식물 상태 알림",
+                            statusMsg
+                    );
+                });
+            }
+
+
+            // 4. 자동제어 - 액션 수행 & 상태 메시지, 액션 푸시 전송
             if (!actions.isEmpty()) {
                 deviceCommandService.executeCommands(plant, actions);
+                userDeviceTokenRepository.findByUser(plant.getUser()).ifPresent(token -> {
+                    fcmService.sendMessage(
+                            token.getToken(),
+                            "🌱자동제어가 작동했어요!",
+                            statusMsg
+                    );
+                });
             }
         }
     }

--- a/src/main/java/com/BioTy/Planty/controller/FCMController.java
+++ b/src/main/java/com/BioTy/Planty/controller/FCMController.java
@@ -34,16 +34,4 @@ public class FCMController {
         fcmService.saveOrUpdateToken(userId, request.getToken());
         return ResponseEntity.ok().build();
     }
-
-    @PostMapping("/send")
-    @Operation(
-            summary = "푸시 알림 테스트 전송",
-            description = "디바이스 토큰을 이용해 알림을 직접 전송합니다."
-    )
-    public ResponseEntity<Void> sendNotification(
-            @RequestBody SendNotificationRequestDto request
-            ){
-        fcmService.sendMessage(request.getTargetToken(), request.getTitle(), request.getBody());
-        return ResponseEntity.ok().build();
-    }
 }

--- a/src/main/java/com/BioTy/Planty/controller/NotificationController.java
+++ b/src/main/java/com/BioTy/Planty/controller/NotificationController.java
@@ -1,0 +1,59 @@
+package com.BioTy.Planty.controller;
+
+import com.BioTy.Planty.dto.notification.NotificationResponseDto;
+import com.BioTy.Planty.entity.User;
+import com.BioTy.Planty.entity.UserNotification;
+import com.BioTy.Planty.repository.UserNotificationRepository;
+import com.BioTy.Planty.repository.UserRepository;
+import com.BioTy.Planty.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "NotificationController", description = "알림 관련 API")
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final UserRepository userRepository;
+    private final UserNotificationRepository userNotificationRepository;
+    private final AuthService authService;
+
+    @Operation(summary = "사용자 알림 목록 조회", description = "특정 사용자의 알림 목록을 최신순으로 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @GetMapping("/me")
+    public List<NotificationResponseDto> getMyNotifications(
+            @Parameter(hidden = true)
+            @RequestHeader("Authorization") String token) {
+        Long userId = authService.getUserIdFromToken(token.replace("Bearer ", ""));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
+
+        return userNotificationRepository.findByUserOrderByReceivedAtDesc(user).stream()
+                .map(NotificationResponseDto::from)
+                .toList();
+    }
+
+    @Operation(summary = "전체 알림 읽음 처리", description = "사용자의 모든 알림을 읽음 상태로 변경합니다.")
+    @PatchMapping("/me/read-all")
+    public void markAllAsRead(
+            @Parameter(hidden = true)
+            @RequestHeader("Authorization") String token
+    ) {
+        Long userId = authService.getUserIdFromToken(token.replace("Bearer ", ""));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
+        List<UserNotification> unreadNotifications = userNotificationRepository.findByUserAndIsReadFalse(user);
+        for (UserNotification notification : unreadNotifications) {
+            notification.setRead(true);
+        }
+        userNotificationRepository.saveAll(unreadNotifications);
+    }
+
+
+}

--- a/src/main/java/com/BioTy/Planty/controller/TestController.java
+++ b/src/main/java/com/BioTy/Planty/controller/TestController.java
@@ -1,0 +1,21 @@
+package com.BioTy.Planty.controller;
+
+import com.BioTy.Planty.config.SensorFetchScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/test")
+public class TestController {
+    private final SensorFetchScheduler sensorFetchScheduler;
+
+    @PostMapping("/run-sensor-fetch")
+    public ResponseEntity<Void> runSensorFetch() {
+        sensorFetchScheduler.fetchSensorDataEveryHour();
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/BioTy/Planty/dto/notification/NotificationResponseDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/notification/NotificationResponseDto.java
@@ -1,0 +1,36 @@
+package com.BioTy.Planty.dto.notification;
+
+import com.BioTy.Planty.entity.UserNotification;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class NotificationResponseDto {
+    private Long id;
+    private String title;
+    private String body;
+    private boolean read;
+    private LocalDateTime receivedAt;
+
+    private Long userPlantId;
+    private String plantName;
+    private String plantImageUrl;
+
+    public static NotificationResponseDto from(UserNotification entity) {
+        NotificationResponseDto dto = new NotificationResponseDto();
+        dto.setId(entity.getId());
+        dto.setTitle(entity.getTitle());
+        dto.setBody(entity.getBody());
+        dto.setRead(entity.isRead());
+        dto.setReceivedAt(entity.getReceivedAt());
+
+        if (entity.getUserPlant() != null) {
+            dto.setUserPlantId(entity.getUserPlant().getId());
+            dto.setPlantName(entity.getUserPlant().getNickname());
+            dto.setPlantImageUrl(entity.getUserPlant().getImageUrl());
+        }
+
+        return dto;
+    }
+}

--- a/src/main/java/com/BioTy/Planty/entity/UserNotification.java
+++ b/src/main/java/com/BioTy/Planty/entity/UserNotification.java
@@ -1,0 +1,28 @@
+package com.BioTy.Planty.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserNotification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private User user;
+
+    @ManyToOne(optional = false)
+    private UserPlant userPlant;
+
+    private String title;
+    private String body;
+    private boolean isRead = false;
+    private LocalDateTime receivedAt;
+}

--- a/src/main/java/com/BioTy/Planty/repository/PlantStatusRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/PlantStatusRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface PlantStatusRepository extends JpaRepository<PlantStatus, Long> {
+    Optional<PlantStatus> findTopByUserPlant_IdOrderByCheckedAtDesc(Long userPlantId);
 }

--- a/src/main/java/com/BioTy/Planty/repository/UserNotificationRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserNotificationRepository.java
@@ -1,0 +1,9 @@
+package com.BioTy.Planty.repository;
+
+import com.BioTy.Planty.entity.UserNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
+}

--- a/src/main/java/com/BioTy/Planty/repository/UserNotificationRepository.java
+++ b/src/main/java/com/BioTy/Planty/repository/UserNotificationRepository.java
@@ -1,9 +1,12 @@
 package com.BioTy.Planty.repository;
 
+import com.BioTy.Planty.entity.User;
 import com.BioTy.Planty.entity.UserNotification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
+    List<UserNotification> findByUserOrderByReceivedAtDesc(User user);
+    List<UserNotification> findByUserAndIsReadFalse(User user);
 }

--- a/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
+++ b/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
@@ -57,8 +57,8 @@ public class DeviceCommandService {
 
                 // 4. 지속시간 후 OFF
                 long delaySeconds = switch (action) {
-                    case "WATER" -> 30;
-                    case "FAN" -> 300;
+                    case "WATER" -> 3;
+                    case "FAN" -> 30;
                     case "LIGHT" -> 300;
                     default -> 0;
                 };

--- a/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
+++ b/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
@@ -70,10 +70,15 @@ public class DeviceCommandService {
                         // 상태 변경
                         command.setStatus("DONE");
                         commandRepository.save(command);
-                        // 센서 데이터 재수집
-                        iotService.fetchAndSaveSensorLog(userPlant.getIotDevice().getId());
-                        // 상태 재평가 및 저장
-                        plantStatusService.evaluatePlantStatus(userPlant.getIotDevice().getId());
+                        // OFF 이후 10초 뒤 센서 재수집 & 상태 재평가
+                        commandScheduler.schedule(() -> {
+                            try {
+                                iotService.fetchAndSaveSensorLog(userPlant.getIotDevice().getId());
+                                plantStatusService.evaluatePlantStatus(userPlant.getIotDevice().getId());
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
+                        }, 10, TimeUnit.SECONDS);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }

--- a/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
+++ b/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
@@ -38,8 +38,8 @@ public class DeviceCommandService {
                 // 2. 명령 지속시간 계산
                 LocalDateTime now = LocalDateTime.now();
                 LocalDateTime willEndAt = switch (action) {
-                    case "WATER" -> now.plusSeconds(30);
-                    case "FAN" -> now.plusMinutes(5);
+                    case "WATER" -> now.plusSeconds(3);
+                    case "FAN" -> now.plusSeconds(30);
                     case "LIGHT" -> now.plusMinutes(5);
                     default -> now.plusSeconds(0);
                 };

--- a/src/main/java/com/BioTy/Planty/service/FCMService.java
+++ b/src/main/java/com/BioTy/Planty/service/FCMService.java
@@ -2,16 +2,19 @@ package com.BioTy.Planty.service;
 
 import com.BioTy.Planty.entity.User;
 import com.BioTy.Planty.entity.UserDeviceToken;
+import com.BioTy.Planty.entity.UserNotification;
+import com.BioTy.Planty.entity.UserPlant;
 import com.BioTy.Planty.repository.UserDeviceTokenRepository;
+import com.BioTy.Planty.repository.UserNotificationRepository;
 import com.BioTy.Planty.repository.UserRepository;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -21,6 +24,7 @@ public class FCMService {
     private final UserDeviceTokenRepository tokenRepository;
     private final UserRepository userRepository;
     private final FirebaseMessaging firebaseMessaging;
+    private final UserNotificationRepository userNotificationRepository;
 
     // 유저 ID 기준으로 FCM 토큰 저장 또는 수정
     @Transactional
@@ -41,11 +45,7 @@ public class FCMService {
     }
 
     // 전달받은 디바이스 토큰에 푸시 메시지 전송
-    public void sendMessage(String targetToken, String title, String body){
-        Notification notification = Notification.builder()
-                .setTitle(title)
-                .setBody(body)
-                .build();
+    public void sendMessage(User user, UserPlant userPlant, String targetToken, String title, String body){
         Message message = Message.builder()
                 .setToken(targetToken)
                 .putData("title", title)
@@ -57,6 +57,14 @@ public class FCMService {
         } catch (Exception e) {
             log.error("FCM 메시지 전송 실패: {}", e);
         }
+
+        userNotificationRepository.save(UserNotification.builder()
+                .user(user)
+                .userPlant(userPlant)
+                .title(title)
+                .body(body)
+                .receivedAt(LocalDateTime.now())
+                .build());
     }
 
 }

--- a/src/main/java/com/BioTy/Planty/service/FCMService.java
+++ b/src/main/java/com/BioTy/Planty/service/FCMService.java
@@ -48,7 +48,8 @@ public class FCMService {
                 .build();
         Message message = Message.builder()
                 .setToken(targetToken)
-                .setNotification(notification)
+                .putData("title", title)
+                .putData("body", body)
                 .build();
         try {
             String response = firebaseMessaging.send(message);

--- a/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
+++ b/src/main/java/com/BioTy/Planty/service/PlantStatusService.java
@@ -31,12 +31,13 @@ public class PlantStatusService {
         UserPlant userPlant = latestLog.getIotDevice().getUserPlant();
         PlantEnvStandards standards = plantEnvStandardsRepository.findByPlantInfo(userPlant.getPlantInfo())
                 .orElseThrow(() -> new RuntimeException("환경 기준 없음"));
+        Personality personality = userPlant.getPersonality();
 
         // 2. 센서값과 환경 기준 비교해 점수 계산 & 상태메시지 생성
         int temperatureScore = calcScore(latestLog.getTemperature(), standards.getMinTemperature(), standards.getMaxTemperature(), "TEMP");
         int lightScore = calcScore(latestLog.getLight(), standards.getMinLight(), standards.getMaxLight(), "LIGHT");
         int humidityScore = calcScore(latestLog.getHumidity(), standards.getMinHumidity(), standards.getMaxHumidity(), "HUMID");
-        String msg = createStatusMessage(temperatureScore, lightScore, humidityScore);
+        String msg = createStatusMessage(temperatureScore, lightScore, humidityScore, personality);
 
         // 3. 명령 판단
         List<String> actionTypes = determinAction(temperatureScore, lightScore, humidityScore);
@@ -109,12 +110,63 @@ public class PlantStatusService {
         }
     }
 
-    private String createStatusMessage(int temp, int light, int humid) {
-        if (temp + light + humid == 9) return "모든 환경이 아주 좋아요!";
-        if (temp == 0) return "온도가 적절하지 않아요!";
-        if (light == 0) return "빛이 부족해요. 햇볕이 필요해요!";
-        if (humid == 0) return "습도가 너무 낮아요. 물이 필요해요!";
-        return "식물의 상태를 다시 확인해주세요.";
+    private String createStatusMessage(int temp, int light, int humid, Personality personality) {
+        String emoji = personality.getEmoji();
+        String tone = personality.getLabel();
+
+        List<String> messages = new ArrayList<>();
+
+        if (temp == 0) messages.add(getMessage("TEMP", tone));
+        if (light == 0) messages.add(getMessage("LIGHT", tone));
+        if (humid == 0) messages.add(getMessage("HUMID", tone));
+
+        if (messages.isEmpty()) {
+            return getMessage("GOOD", tone);
+        }
+
+        return String.join("\n", messages);
+    }
+
+
+    private String getMessage(String type, String tone) {
+        return switch (tone) {
+            case "joy" -> switch (type) {
+                case "TEMP" -> "와~ 덥다! 시원한 바람 한 번 부탁해요! 😂";
+                case "LIGHT" -> "햇빛이 좀 부족한 느낌이에요! 햇살 플리즈~ ☀️";
+                case "HUMID" -> "촉촉함이 그리운 날이에요! 물 한 모금 주실래요? 💧";
+                case "GOOD" -> "기분 최고야! 오늘도 무럭무럭 자라날 기분! 🌿🥰";
+                default -> "";
+            };
+            case "fear" -> switch (type) {
+                case "TEMP" -> "온도가 너무 높은 거 아니에요…? 괜찮은 건가요? 🥺";
+                case "LIGHT" -> "너무 어두운 거 같아요… 혹시 불 꺼진 건 아니죠? 🥺";
+                case "HUMID" -> "흙이 너무 말랐어요…🥺 이거 위험하지 않나요? ";
+                case "GOOD" -> "다행이다… 지금 상태는 좋아 보여요! 안심이에요 🌱";
+                default -> "";
+            };
+            case "sadness" -> switch (type) {
+                case "TEMP" -> "좀 더운 것 같아... 살짝 지치네요 😭";
+                case "LIGHT" -> "깜깜해서 기분이 좀 가라앉아요...";
+                case "HUMID" -> "오늘… 물을 못 받은 건가..? 슬퍼요 😢";
+                case "GOOD" -> "오늘은 상태 괜찮은 것 같아... 고마워요... 🥹";
+                default -> "";
+            };
+            case "anger" -> switch (type) {
+                case "TEMP" -> "이대로 두면 진짜 열받는다니까! 팬 어딨어!! 🤯";
+                case "LIGHT" -> "이 어둠 속에서 자라라고요? 농담이죠? 😡 ";
+                case "HUMID" -> "이대로 두면 말라죽는다! 얼른 물 줘!! 💧";
+                case "GOOD" -> "그래, 이 정도면 불만 없어. 잘했어. 😤";
+                default -> "";
+            };
+            case "disgust" -> switch (type) {
+                case "TEMP" -> "여기… 이 온도 말이 되나요? 최악이에요 🙄";
+                case "LIGHT" -> "이 빛 상태… 감성 실종 🙄 컨디션 떨어져요";
+                case "HUMID" -> "촉촉함 제로… 이 상태에서 살라고요? 정말? 💧";
+                case "GOOD" -> "오늘은 신경 좀 썼나요? 나쁘지 않네요. 🙃";
+                default -> "";
+            };
+            default -> "식물 상태를 확인해 주세요!";
+        };
     }
 
     private List<String> determinAction(int tempScore, int lightScore, int humidScore){


### PR DESCRIPTION
### Pull Request
자동제어 조건에 따라 상태를 갱신하고 명령을 실행함에 따라 FCM 알림 전송 수행 & 알림 로그를 기록

**🪾작업한 브랜치**
- feat/# 25-auto-control-fcm

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-BE/issues/25
- https://github.com/Team-BIoTy/Planty-FE/issues/27

**🔥 작업 내용**
- 매시 정각마다 IoT 기기 연결된 식물 상태 평가 및 알림 전송 로직 추가
   - 자동제어모드인 경우, 액션 시작 시 "🌱자동제어가 작동했어요!" FCM 알림 전송
   - 그 외 상태 이상 감지 시 "🌱식물 상태 알림" FCM 알림 전송
- UserNotification 엔티티를 통한 알림 로그 저장
- 사용자 알림 목록 조회, 알림 전체 읽음 처리 API 구현
- 명령 종료 후 10초 지연 후 센서 데이터 재수집 및 상태 재평가