### PR TITLE
[fix] #35 - chatbot api에 type 매개변수 추가 (slm, llm 선택)

### DIFF
--- a/src/main/java/com/BioTy/Planty/controller/ChatController.java
+++ b/src/main/java/com/BioTy/Planty/controller/ChatController.java
@@ -87,7 +87,8 @@ public class ChatController {
                 request.getPlantInfo(),
                 request.getSensorLogId(),
                 request.getPlantEnvStandardsId(),
-                request.getPersona()
+                request.getPersona(),
+                request.getType()
         );
         return ResponseEntity.ok(response);
     }
@@ -98,8 +99,9 @@ public class ChatController {
     ) {
         Long chatRoomId = requestBody.containsKey("chatRoomId") ? Long.valueOf(requestBody.get("chatRoomId").toString()) : null;
         String userInput = requestBody.get("userInput").toString();
+        String type = requestBody.get("type").toString();
 
-        String answer = chatService.callPlantQAAgent(chatRoomId, userInput);
+        String answer = chatService.callPlantQAAgent(chatRoomId, userInput, type);
 
         ChatMessageResponseDto response = new ChatMessageResponseDto("BOT", answer, LocalDateTime.now());
         return ResponseEntity.ok(response);

--- a/src/main/java/com/BioTy/Planty/dto/chat/SendMessageRequestDto.java
+++ b/src/main/java/com/BioTy/Planty/dto/chat/SendMessageRequestDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SendMessageRequestDto {
+    private String type; // slm 또는 llm
     private String message;
     private PlantInfo plantInfo;
     private Long sensorLogId;

--- a/src/main/java/com/BioTy/Planty/service/ChatService.java
+++ b/src/main/java/com/BioTy/Planty/service/ChatService.java
@@ -1,9 +1,6 @@
 package com.BioTy.Planty.service;
 
-import com.BioTy.Planty.dto.chat.ChatIdResponseDto;
-import com.BioTy.Planty.dto.chat.ChatMessageResponseDto;
-import com.BioTy.Planty.dto.chat.ChatRoomDetailDto;
-import com.BioTy.Planty.dto.chat.ChatRoomSummaryDto;
+import com.BioTy.Planty.dto.chat.*;
 import com.BioTy.Planty.entity.*;
 import com.BioTy.Planty.repository.ChatMessageRepository;
 import com.BioTy.Planty.repository.ChatRoomRepository;
@@ -135,7 +132,7 @@ public class ChatService {
 
     // 4. 메시지 전송
     public ChatMessageResponseDto sendMessage(Long chatRoomId, String message, PlantInfo info,
-                                              Long sensorLogId, Long plantEnvStandardsId, String persona) {
+                                              Long sensorLogId, Long plantEnvStandardsId, String persona, String type) {
         // 1) 사용자 메시지 저장
         ChatMessage userMsg = chatMessageRepository.save(
                 new ChatMessage(chatRoomId, ChatMessage.Sender.USER, message)
@@ -147,6 +144,7 @@ public class ChatService {
             String aiServerUrl = "http://localhost:8000/chat";
 
             Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("type", type);
             requestBody.put("chat_room_id", chatRoomId);
             requestBody.put("sensor_log_id", sensorLogId);
             requestBody.put("plant_env_standards_id", plantEnvStandardsId);
@@ -240,10 +238,11 @@ public class ChatService {
         );
     }
 
-    public String callPlantQAAgent(Long chatRoomId, String userInput) {
+    public String callPlantQAAgent(Long chatRoomId, String userInput, String type) {
         String aiServerUrl = "http://localhost:8000/plant_qa";
 
         Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("type", type);
         requestBody.put("user_input", userInput);
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
+++ b/src/main/java/com/BioTy/Planty/service/DeviceCommandService.java
@@ -39,8 +39,8 @@ public class DeviceCommandService {
                 LocalDateTime now = LocalDateTime.now();
                 LocalDateTime willEndAt = switch (action) {
                     case "WATER" -> now.plusSeconds(3);
-                    case "FAN" -> now.plusSeconds(30);
-                    case "LIGHT" -> now.plusSeconds(30);
+                    case "FAN" -> now.plusSeconds(15);
+                    case "LIGHT" -> now.plusSeconds(15);
                     default -> now.plusSeconds(0);
                 };
 
@@ -58,8 +58,8 @@ public class DeviceCommandService {
                 // 4. 지속시간 후 OFF
                 long delaySeconds = switch (action) {
                     case "WATER" -> 3;
-                    case "FAN" -> 30;
-                    case "LIGHT" -> 30;
+                    case "FAN" -> 15;
+                    case "LIGHT" -> 15;
                     default -> 0;
                 };
 


### PR DESCRIPTION
### Pull Request
챗봇 SLM/LLM 선택 가능하도록 API 연동 코드 및 UI 수정

**🪾작업한 브랜치**
- fix/# 35-chatbot-select

**🎯 관련 이슈**
- https://github.com/Team-BIoTy/Planty-FE/issues/35
- https://github.com/Team-BIoTy/Planty-BE/issues/35

**🔥 작업 내용**
- ai 서버 api 수정에 따른 반영 (type 추가)